### PR TITLE
/update and $sendupdate

### DIFF
--- a/src/messagecommands/SendUpdate.ts
+++ b/src/messagecommands/SendUpdate.ts
@@ -1,0 +1,36 @@
+import { Message, Permissions, MessageEmbed, TextChannel } from 'discord.js';
+import { Bot } from '../Bot';
+import { MessageCommand } from './MessageCommand';
+import config from '../../config.json';
+import { updateChannels } from '../slashcommands/Update';
+
+export class SendUpdate implements MessageCommand {
+	name: string = 'sendupdate';
+	requiredPermissions: bigint[] = [Permissions.FLAGS.SEND_MESSAGES];
+	async run(
+		bot: Bot,
+		message: Message<boolean>,
+		args: string[]
+	): Promise<void> {
+		let user = message.author;
+		if (user.id != config.owner) {
+			return; //we dont need to respond because as far as anyone cares this command does not matter
+		}
+		let content = message.content.slice(12); //cuts out "$sendupdate "
+		let embed = new MessageEmbed()
+			.setColor('#FFFFFF')
+			.setTitle(':mirror: **__Mirror Update!__** <:homies:863998146589360158>')
+			.setDescription(content)
+			.setFooter({
+				text: 'Ford, Fordle#0001',
+				iconURL: 'https://imgur.com/pxkMn14.jpg',
+			});
+		updateChannels.forEach(async (channel) => {
+			let channelToUpdate = bot.client.channels!.cache.get(
+				channel.toString()
+			) as TextChannel;
+			if (!channelToUpdate) return;
+			await channelToUpdate.send({ embeds: [embed] });
+		});
+	}
+}

--- a/src/slashcommands/Update.ts
+++ b/src/slashcommands/Update.ts
@@ -1,0 +1,80 @@
+import { Bot } from '../Bot';
+import {
+	Permissions,
+	CommandInteraction,
+	CacheType,
+	GuildMember,
+	TextChannel,
+	Guild,
+} from 'discord.js';
+import { SlashCommand } from './SlashCommand';
+import config from '../../config.json';
+import Enmap from 'enmap';
+
+export let updateChannels = new Enmap({ name: 'updateChannels' });
+
+export class Update implements SlashCommand {
+	public name = 'update';
+	public registerData = {
+		name: this.name,
+		description:
+			'Set the channel you wish to recieve Mirror update messages in',
+		options: [
+			{
+				name: 'channel',
+				description: 'The channel you wish to recieve update messages',
+				type: 7,
+				required: true,
+			},
+		],
+	};
+	public requiredPermissions = [Permissions.FLAGS.SEND_MESSAGES];
+
+	public async run(
+		bot: Bot,
+		interaction: CommandInteraction<CacheType>
+	): Promise<void> {
+		if (!(interaction.channel instanceof TextChannel)) {
+			interaction.reply('Command must be used in a server');
+			return;
+		}
+		let member = interaction.member as GuildMember;
+		if (
+			!member.permissionsIn(interaction.channel!).has('ADMINISTRATOR') ||
+			member.id != config.owner
+		) {
+			interaction.reply({
+				content:
+					'This command is only for people with Administrator permissions',
+				ephemeral: true,
+			});
+			return;
+		}
+		let channel = interaction.options.getChannel('channel');
+		if (
+			!interaction.guild?.me
+				?.permissionsIn(channel?.id!)
+				.has('SEND_MESSAGES') ||
+			!interaction.guild?.me?.permissionsIn(channel?.id!).has('EMBED_LINKS')
+		) {
+			interaction.reply({
+				content:
+					'Mirror does not have permissions to send messages in the specified channel',
+				ephemeral: true,
+			});
+			return;
+		}
+		if (channel!.type != 'GUILD_TEXT')
+			return interaction.reply({
+				content: 'Channel must be a text channel',
+				ephemeral: true,
+			});
+		//var enmapChannel = updateChannels.ensure(interaction.guild.id, '');
+		updateChannels.set(interaction.guild.id, channel?.id);
+		interaction.reply({
+			content: `Sucessfully updated your development messages to ${channel}`,
+			ephemeral: false,
+		});
+		return;
+	}
+}


### PR DESCRIPTION
Creates slash command update which allows server admins to choose which text channel they wish to receive mirror updates on

Creates a keyword command $sendupdate which can only be used by config.owner and sends an update message to all servers with a selected update channel. 