### PR TITLE
Guild specific commands

### DIFF
--- a/src/events/InteractionCreate.ts
+++ b/src/events/InteractionCreate.ts
@@ -16,6 +16,15 @@ export class InteractionCreate implements EventHandler {
 		//we didn't find it, exit
 		if (!command) return;
 
+		//if the command needs to be run in a server setting
+		if (command.guildRequired) {
+			//If the command is used in anything but a server, return
+			if (!(interaction.channel instanceof TextChannel)) {
+				interaction.reply('Command must be used in a server');
+				return;
+			}
+		}
+
 		//if the command requires permissions
 		if (command.requiredPermissions) {
 			if (

--- a/src/slashcommands/BanIntro.ts
+++ b/src/slashcommands/BanIntro.ts
@@ -71,4 +71,5 @@ export class BanIntro implements SlashCommand {
 			}
 		}
 	}
+	guildRequired?: boolean = true;
 }

--- a/src/slashcommands/Birthday.ts
+++ b/src/slashcommands/Birthday.ts
@@ -197,17 +197,15 @@ export class Birthday implements SlashCommand {
 			return;
 		}
 		if (interaction.options.getSubcommand() == 'config') {
-			//If the command is used in a DM, return
-			if (!(interaction.channel instanceof TextChannel)) {
-				interaction.reply('Command must be used in a server');
-				return;
-			}
-
 			//set the interaction member object so we can refer to their permissions
 			let member = interaction.member as GuildMember;
 
 			//check if the user is an administrator
-			if (!member.permissionsIn(interaction.channel!).has('ADMINISTRATOR')) {
+			if (!(interaction.channel instanceof TextChannel)) {
+				interaction.reply('Command must be used in a server');
+				return;
+			}
+			if (!member.permissionsIn(interaction.channel).has('ADMINISTRATOR')) {
 				interaction.reply({
 					content:
 						'This command is only for people with Administrator permissions',
@@ -282,4 +280,5 @@ export class Birthday implements SlashCommand {
 			return;
 		}
 	}
+	guildRequired? = true;
 }

--- a/src/slashcommands/Intro.ts
+++ b/src/slashcommands/Intro.ts
@@ -74,4 +74,5 @@ export class Intro implements SlashCommand {
 			return;
 		}
 	}
+	guildRequired?: boolean = true;
 }

--- a/src/slashcommands/Join.ts
+++ b/src/slashcommands/Join.ts
@@ -44,4 +44,5 @@ export class Join implements SlashCommand {
 		interaction.reply({ content: 'success', ephemeral: true }); //hides the reply to anyone but the user
 		return;
 	}
+	guildRequired?: boolean = true;
 }

--- a/src/slashcommands/Leave.ts
+++ b/src/slashcommands/Leave.ts
@@ -29,4 +29,5 @@ export class Leave implements SlashCommand {
 		interaction.reply('Left the voice channel :wave:');
 		return;
 	}
+	guildRequired?: boolean = true;
 }

--- a/src/slashcommands/Sicko.ts
+++ b/src/slashcommands/Sicko.ts
@@ -45,4 +45,5 @@ export class Sicko implements SlashCommand {
 		interaction.reply('reply lol');
 		return;
 	}
+	guildRequired?: boolean = true;
 }

--- a/src/slashcommands/SlashCommand.ts
+++ b/src/slashcommands/SlashCommand.ts
@@ -2,13 +2,17 @@
 import { Bot } from '../Bot';
 import {
 	ApplicationCommandDataResolvable,
-	ChatInputApplicationCommandData,
 	CommandInteraction,
 } from 'discord.js';
 
 export interface SlashCommand {
+	//name of the slash command as discord will register it. Must be all lowercase.
 	name: string;
 	registerData: ApplicationCommandDataResolvable;
+	//an array of Permissions.FLAGS
 	requiredPermissions: Array<bigint>;
+	//function that will run on command execution
 	run(bot: Bot, interaction: CommandInteraction): Promise<void>;
+	//if the command needs to be run inside a guild
+	guildRequired?: boolean;
 }

--- a/src/slashcommands/Update.ts
+++ b/src/slashcommands/Update.ts
@@ -77,4 +77,5 @@ export class Update implements SlashCommand {
 		});
 		return;
 	}
+	guildRequired?: boolean = true;
 }


### PR DESCRIPTION
Creates an optional variable guildRequired on the slash command interface, making it so you can specify if a slash command needs to be run inside of a guild or not. Performs the check and informs the user of invalid usage in InteractionCreate
