### PR TITLE
Join Event and NSFW toggler

### DIFF
--- a/src/events/GuildCreate.ts
+++ b/src/events/GuildCreate.ts
@@ -1,0 +1,26 @@
+import { EventHandler } from './EventHandler';
+import { Bot } from '../Bot';
+import { Guild, MessageEmbed, TextChannel, Permissions } from 'discord.js';
+import { permissionsCheck } from '../resources/permissionsCheck';
+
+export class GuildCreate implements EventHandler {
+	eventName = 'guildCreate';
+	async process(bot: Bot, guild: Guild): Promise<void> {
+		//Check Guild for channels
+		let channelList = await guild.channels.fetch();
+        for(let chan of channelList){
+            if (chan == TextChannel) {
+        }
+		(await channelList).forEach(async (channel) => {
+			if (channel.type == 'GUILD_TEXT') {
+				await channel.send('test');
+			}
+		});
+
+		//Find the first channel where discord can send embeds and messages
+
+		//send "welcome embed"
+
+		//if they do not have perms to embed, send plain text
+	}
+}

--- a/src/events/GuildCreate.ts
+++ b/src/events/GuildCreate.ts
@@ -1,26 +1,30 @@
 import { EventHandler } from './EventHandler';
 import { Bot } from '../Bot';
-import { Guild, MessageEmbed, TextChannel, Permissions } from 'discord.js';
-import { permissionsCheck } from '../resources/permissionsCheck';
+import {
+	Guild,
+	MessageEmbed,
+	TextChannel,
+	Permissions,
+	GuildChannel,
+} from 'discord.js';
 
 export class GuildCreate implements EventHandler {
 	eventName = 'guildCreate';
 	async process(bot: Bot, guild: Guild): Promise<void> {
+		let embed = new MessageEmbed()
+			.setTitle('**:mirror: Mirror has arrived!**')
+			.setDescription(
+				'Thanks for inviting Mirror to your server! \n\n To get started with Mirror use **`/help`** for more information about commands and functionality\n\nUse **`/config`** to see what else you can do before Mirror is fully functional'
+			)
+			.setColor('#FFFFFF');
 		//Check Guild for channels
 		let channelList = await guild.channels.fetch();
-        for(let chan of channelList){
-            if (chan == TextChannel) {
-        }
 		(await channelList).forEach(async (channel) => {
-			if (channel.type == 'GUILD_TEXT') {
-				await channel.send('test');
+			if (channel.permissionsFor(guild.me!).has('SEND_MESSAGES')) {
+				console.log('New guild test');
+				let newChannel = channel as TextChannel;
+				return await newChannel.send({ embeds: [embed] });
 			}
 		});
-
-		//Find the first channel where discord can send embeds and messages
-
-		//send "welcome embed"
-
-		//if they do not have perms to embed, send plain text
 	}
 }

--- a/src/events/GuildCreate.ts
+++ b/src/events/GuildCreate.ts
@@ -20,7 +20,11 @@ export class GuildCreate implements EventHandler {
 			.setColor('#FFFFFF');
 		let channelList = await guild.channels.fetch();
 		for (let channel of channelList) {
-			if (channel[1].permissionsFor(guild.me!).has('SEND_MESSAGES')) {
+			if (
+				channel[1].permissionsFor(guild.me!).has('VIEW_CHANNEL') &&
+				channel[1].permissionsFor(guild.me!).has('SEND_MESSAGES') &&
+				channel[1].type == 'GUILD_TEXT'
+			) {
 				let newChannel = channel[1] as TextChannel;
 				await newChannel.send({ embeds: [embed] });
 				break;

--- a/src/events/GuildCreate.ts
+++ b/src/events/GuildCreate.ts
@@ -6,6 +6,7 @@ import {
 	TextChannel,
 	Permissions,
 	GuildChannel,
+	NonThreadGuildBasedChannel,
 } from 'discord.js';
 
 export class GuildCreate implements EventHandler {
@@ -17,14 +18,14 @@ export class GuildCreate implements EventHandler {
 				'Thanks for inviting Mirror to your server! \n\n To get started with Mirror use **`/help`** for more information about commands and functionality\n\nUse **`/config`** to see what else you can do before Mirror is fully functional'
 			)
 			.setColor('#FFFFFF');
-		//Check Guild for channels
 		let channelList = await guild.channels.fetch();
-		(await channelList).forEach(async (channel) => {
-			if (channel.permissionsFor(guild.me!).has('SEND_MESSAGES')) {
-				console.log('New guild test');
-				let newChannel = channel as TextChannel;
-				return await newChannel.send({ embeds: [embed] });
+		for (let channel of channelList) {
+			if (channel[1].permissionsFor(guild.me!).has('SEND_MESSAGES')) {
+				let newChannel = channel[1] as TextChannel;
+				await newChannel.send({ embeds: [embed] });
+				break;
 			}
-		});
+		}
+		return;
 	}
 }

--- a/src/slashcommands/Help.ts
+++ b/src/slashcommands/Help.ts
@@ -21,6 +21,8 @@ export class Help implements SlashCommand {
 	requiredPermissions: bigint[] = [
 		Permissions.FLAGS.SEND_MESSAGES,
 		Permissions.FLAGS.EMBED_LINKS,
+		Permissions.FLAGS.MANAGE_MESSAGES,
+		Permissions.FLAGS.ADD_REACTIONS,
 	];
 	async run(bot: Bot, interaction: CommandInteraction): Promise<void> {
 		//TODO: Add permission checks

--- a/src/slashcommands/Nsfw.ts
+++ b/src/slashcommands/Nsfw.ts
@@ -1,0 +1,53 @@
+import { ApplicationCommandDataResolvable, CommandInteraction, CacheType, ChatInputApplicationCommandData, Permissions, MessageEmbed } from 'discord.js';
+import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
+import Enmap from 'enmap';
+import { Bot } from '../Bot';
+import { SlashCommand } from './SlashCommand';
+
+const choices = [{
+    name: 'On',
+    value: 'on',
+}, {
+    name: 'Off',
+    value: 'off',
+}]
+
+export let nsfw = new Enmap({ name: 'nsfw'});
+
+export class Nsfw implements SlashCommand {
+    name: string = 'nsfw'
+    registerData: ChatInputApplicationCommandData = {
+        name: this.name,
+        description: 'Check your current NSFW setting, or toggle it ON or OFF',
+        options: [{
+            name: 'toggle',
+            description: 'Switch your servers NSFW status to ON or OFF',
+            type: ApplicationCommandOptionTypes.STRING,
+            required: false,
+            choices: choices,
+        }]
+    }
+    requiredPermissions: bigint[] = [
+        Permissions.FLAGS.SEND_MESSAGES,
+    ]
+    async run(bot: Bot, interaction: CommandInteraction<CacheType>): Promise<void> {
+        var setting = nsfw.ensure(interaction.guild!.id, 'off');
+        const embed = new MessageEmbed();
+        if(interaction.options.getString('toggle')=='on'){
+            nsfw.set(interaction.guild!.id, 'on');
+            embed.setDescription('NSFW has been toggled `ON`');
+            interaction.reply({embeds:[embed]});
+            return;
+        }
+        if(interaction.options.getString('toggle')=='off'){
+            nsfw.set(interaction.guild!.id, 'off');
+            embed.setDescription('NSFW has been toggled `OFF`');
+            interaction.reply({embeds: [embed]});
+            return;
+        }
+        embed.setDescription(`Your NSFW settings are currently set to ${setting}`)
+        interaction.reply({embeds: [embed]});
+        return;
+    }
+
+}

--- a/src/slashcommands/Rockcrafts.ts
+++ b/src/slashcommands/Rockcrafts.ts
@@ -26,6 +26,7 @@ export class Rockcrafts implements SlashCommand {
 		Permissions.FLAGS.SEND_MESSAGES,
 		Permissions.FLAGS.MANAGE_MESSAGES,
 		Permissions.FLAGS.ADD_REACTIONS,
+		Permissions.FLAGS.EMBED_LINKS,
 	];
 	async run(
 		bot: Bot,


### PR DESCRIPTION
Adds GuildCreate event which fires each time Mirror joins a new guild. Sends the following message:
![image](https://user-images.githubusercontent.com/90861679/156938401-bfa36574-706c-414f-afc6-f3508eea5baf.png)

Please review this messages content and lmk if you think there is something we should add or tweak.

Adds NSFW toggler for admins to enable or disable NSFW commands/content
