### PR TITLE
Splits birthday subcommands into new files

### DIFF
--- a/src/events/Ready.ts
+++ b/src/events/Ready.ts
@@ -1,6 +1,6 @@
 import { EventHandler } from './EventHandler';
 import { Bot } from '../Bot';
-import { bdayTimes } from '../slashcommands/Birthday';
+import { bdayTimes } from '../slashcommands/BirthdayConfig';
 import { birthdayTimer } from '../resources/birthdayTimer';
 import { registerSlashCommands } from '../resources/registerSlashCommands';
 import { launchVoice } from '../slashcommands/DefaultVc';

--- a/src/resources/birthdayTimer.ts
+++ b/src/resources/birthdayTimer.ts
@@ -1,8 +1,9 @@
-import { bdayDates, bdayTimes, bdayChannels } from '../slashcommands/Birthday';
+import { bdayDates } from '../slashcommands/Birthday';
 import cron from 'node-cron';
 import { Bot } from '../Bot';
 import { MessageEmbed, TextChannel, User } from 'discord.js';
 import Enmap from 'enmap';
+import { bdayChannels, bdayTimes } from '../slashcommands/BirthdayConfig';
 
 export let bdayCrons = new Enmap();
 

--- a/src/slashcommands/Birthday.ts
+++ b/src/slashcommands/Birthday.ts
@@ -6,11 +6,11 @@ import {
 	TextChannel,
 	GuildChannel,
 	MessageEmbed,
+	ApplicationCommandDataResolvable,
 } from 'discord.js';
 import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 import Enmap from 'enmap';
 import { Bot } from '../Bot';
-import { birthdayTimer } from '../resources/birthdayTimer';
 import { SlashCommand } from './SlashCommand';
 
 type monthIndex = { [index: string]: number };
@@ -78,99 +78,28 @@ const months = [
 		value: 'december',
 	},
 ];
-const timezones = [
-	{
-		name: 'EST',
-		value: 'est',
-	},
-	{
-		name: 'CST',
-		value: 'cst',
-	},
-	{
-		name: 'MST',
-		value: 'mst',
-	},
-	{
-		name: 'PST',
-		value: 'pst',
-	},
-];
-type timeIndex = { [index: string]: number };
-const timezoneCode = {
-	est: 1,
-	cst: 0,
-	gmt: -1,
-	pst: -2,
-} as timeIndex;
 
 export let bdayDates = new Enmap({ name: 'bdayDates' });
-export let bdayChannels = new Enmap({ name: 'bdayChannels' });
-export let bdayTimes = new Enmap({ name: 'bdayTimes' });
 
 export class Birthday implements SlashCommand {
 	name: string = 'birthday';
-	registerData = {
+	registerData: ApplicationCommandDataResolvable = {
 		name: this.name,
 		description:
 			'Set your birthday to recieve a Birthday message on your birthday!',
 		options: [
 			{
-				name: 'set',
-				description: 'Set your birthday',
-				type: 1,
-				required: false,
-				options: [
-					{
-						name: 'month',
-						description: 'Your birth month',
-						type: ApplicationCommandOptionTypes.STRING,
-						required: true,
-						choices: months,
-					},
-					{
-						name: 'day',
-						description: 'The date of your birthday',
-						type: ApplicationCommandOptionTypes.INTEGER,
-						required: true,
-					},
-				],
+				name: 'month',
+				description: 'Your birth month',
+				type: ApplicationCommandOptionTypes.STRING,
+				required: true,
+				choices: months,
 			},
 			{
-				name: 'config',
-				description:
-					'[ADMIN ONLY] Configure the time and channel to send the birthday messages',
-				type: 1,
-				required: false,
-				options: [
-					{
-						name: 'channel',
-						description:
-							'Set the channel where the birthday messages are sent to',
-						required: true,
-						type: ApplicationCommandOptionTypes.CHANNEL,
-					},
-					{
-						name: 'hour',
-						description:
-							'The hour you want to send Birthday messages in local time, military format (0-23)',
-						type: 'INTEGER',
-						required: true,
-					},
-					{
-						name: 'minute',
-						description: 'The minute you want to send Birthday messages',
-						type: 'INTEGER',
-						required: true,
-					},
-					{
-						name: 'timezone',
-						description: 'Your local timezone',
-						type: 'STRING',
-						required: true,
-						choices: timezones,
-					},
-				],
+				name: 'day',
+				description: 'The date of your birthday',
+				type: ApplicationCommandOptionTypes.INTEGER,
+				required: true,
 			},
 		],
 	};
@@ -179,106 +108,24 @@ export class Birthday implements SlashCommand {
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
-		if (interaction.options.getSubcommand() == 'set') {
-			//store the date of birth in numerical form  DD-MM
-			let formattedBirthday = `${interaction.options.getInteger('day')}-${
-				monthCode[interaction.options.getString('month')!]
-			}`;
+		//store the date of birth in numerical form  DD-MM
+		let formattedBirthday = `${interaction.options.getInteger('day')}-${
+			monthCode[interaction.options.getString('month')!]
+		}`;
 
-			//set the new birthday into the enmap
-			bdayDates.set(interaction.user.id, formattedBirthday);
-			let monthCap = interaction.options.getString('month')!.charAt(0).toUpperCase() + interaction.options.getString('month')!.slice(1);
-			let embed = new MessageEmbed()
-				.setDescription(`Successfully set your birthday to: ${monthCap} ${interaction.options.getInteger(
+		//set the new birthday into the enmap
+		bdayDates.set(interaction.user.id, formattedBirthday);
+		let monthCap =
+			interaction.options.getString('month')!.charAt(0).toUpperCase() +
+			interaction.options.getString('month')!.slice(1);
+		let embed = new MessageEmbed()
+			.setDescription(
+				`Successfully set your birthday to: ${monthCap} ${interaction.options.getInteger(
 					'day'
-				)}`)
-				.setColor('#FFFFFF');
-			interaction.reply({embeds:[embed]});
-			return;
-		}
-		if (interaction.options.getSubcommand() == 'config') {
-			//set the interaction member object so we can refer to their permissions
-			let member = interaction.member as GuildMember;
-
-			//check if the user is an administrator
-			if (!(interaction.channel instanceof TextChannel)) {
-				interaction.reply('Command must be used in a server');
-				return;
-			}
-			if (!member.permissionsIn(interaction.channel).has('ADMINISTRATOR')) {
-				interaction.reply({
-					content:
-						'This command is only for people with Administrator permissions',
-					ephemeral: true,
-				});
-				return;
-			}
-
-			//recieve the provided channel and check if its a text channel
-			var guildChannel = interaction.options.getChannel('channel') as GuildChannel;
-			if (guildChannel.type != 'GUILD_TEXT') {
-				interaction.reply({
-					content: 'Please enter a valid text channel',
-					ephemeral: true,
-				});
-				return;
-			}
-
-			//set the channel in the enmap
-			bdayChannels.set(interaction.guild!.id, guildChannel.id);
-
-			//get the hour and ensure that it is valid
-			let hour = interaction.options.getInteger('hour')!;
-			if (hour > 23 || hour < 0){
-				return interaction.reply({
-					content:
-						'Invalid hour, please use military format (0-23) where 0 represents midnight.',
-					ephemeral: true,
-				});
-			}
-			//get the minute and ensure that it is valid
-			let minute = interaction.options.getInteger('minute')!;
-			if (minute > 60 || minute < 0){
-				return interaction.reply({
-					content: 'Invalid minute, please provide an integer between 0 and 60',
-					ephemeral: true,
-				});
-			}
-
-			//get the timezone and modify the time to create parity with CST
-			let timezone = interaction.options.getString('timezone')!;
-			let tzChange = timezoneCode[timezone];
-			let cst = hour + tzChange;
-
-			//if the timezone requires the bot to scan for a different day, store a modifier that will be used in the scheduler
-			let date = 'x';
-			if (cst + tzChange >= 24) {
-				date = 'plus';
-				cst -= 24;
-			}
-			if (cst + tzChange < 0) {
-				date = 'minus';
-				cst += 24;
-			}
-
-			//set the infostring to be set into the scheduler, Format: MM-HH-DATEMOD-TIMEZONE
-			let infostring = `${minute}-${hour}-${date}-${timezone}`;
-			bdayTimes.set(interaction.guild!.id, infostring); //scheduler enmap
-			birthdayTimer(interaction.guild!.id, bot); //scheduler
-
-			//respond and exit
-			let hourText = hour.toString();
-			let minuteText = minute.toString();
-			if(hour<10) hourText = '0' + hourText;
-			if(minute<10) minuteText = '0' + minuteText;
-			let embed = new MessageEmbed()
-				.setColor('#ffffff')
-				.setDescription(`Successfully configured your birthday timer to trigger at ${hourText}:${minuteText} \`${timezone.toUpperCase()}\` in ${interaction.options.getChannel(
-					'channel'
-				)}`);
-			interaction.reply({embeds: [embed]});
-			return;
-		}
+				)}`
+			)
+			.setColor('#FFFFFF');
+		interaction.reply({ embeds: [embed] });
+		return;
 	}
-	guildRequired? = true;
 }

--- a/src/slashcommands/BirthdayConfig.ts
+++ b/src/slashcommands/BirthdayConfig.ts
@@ -1,0 +1,165 @@
+import {
+	ApplicationCommandDataResolvable,
+	CommandInteraction,
+	CacheType,
+	GuildMember,
+	TextChannel,
+	GuildChannel,
+	MessageEmbed,
+} from 'discord.js';
+import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
+import { Bot } from '../Bot';
+import { SlashCommand } from './SlashCommand';
+import { birthdayTimer } from '../resources/birthdayTimer';
+import Enmap from 'enmap';
+
+const timezones = [
+	{ name: 'GMT', value: 'gmt' },
+	{ name: 'CET', value: 'cet' },
+	{ name: 'EET', value: 'eet' },
+	{ name: 'EST', value: 'est' },
+	{ name: 'CST', value: 'cst' },
+	{ name: 'MST', value: 'mst' },
+	{ name: 'PST', value: 'pst' },
+];
+type timeIndex = { [index: string]: number };
+const timezoneCode = {
+	eet: 8,
+	cet: 7,
+	gmt: 6,
+	est: 1,
+	cst: 0,
+	mst: -1,
+	pst: -2,
+} as timeIndex;
+
+export let bdayChannels = new Enmap({ name: 'bdayChannels' });
+export let bdayTimes = new Enmap({ name: 'bdayTimes' });
+
+export class BirthdayConfig implements SlashCommand {
+	name: string = 'birthdayconfig';
+	registerData: ApplicationCommandDataResolvable = {
+		name: this.name,
+		description:
+			'[ADMIN ONLY] Configure the time and channel to send the birthday messages',
+		options: [
+			{
+				name: 'channel',
+				description: 'Set the channel where the birthday messages are sent to',
+				required: true,
+				type: ApplicationCommandOptionTypes.CHANNEL,
+			},
+			{
+				name: 'hour',
+				description:
+					'The hour you want to send Birthday messages in local time, military format (0-23)',
+				type: 'INTEGER',
+				required: true,
+			},
+			{
+				name: 'minute',
+				description: 'The minute you want to send Birthday messages',
+				type: 'INTEGER',
+				required: true,
+			},
+			{
+				name: 'timezone',
+				description: 'Your local timezone',
+				type: 'STRING',
+				required: true,
+				choices: timezones,
+			},
+		],
+	};
+	requiredPermissions: bigint[] = [];
+	async run(
+		bot: Bot,
+		interaction: CommandInteraction<CacheType>
+	): Promise<void> {
+		let member = interaction.member as GuildMember;
+
+		//check if the user is an administrator
+		if (!(interaction.channel instanceof TextChannel)) {
+			interaction.reply('Command must be used in a server');
+			return;
+		}
+		if (!member.permissionsIn(interaction.channel).has('ADMINISTRATOR')) {
+			interaction.reply({
+				content:
+					'This command is only for people with Administrator permissions',
+				ephemeral: true,
+			});
+			return;
+		}
+
+		//recieve the provided channel and check if its a text channel
+		var guildChannel = interaction.options.getChannel(
+			'channel'
+		) as GuildChannel;
+		if (guildChannel.type != 'GUILD_TEXT') {
+			interaction.reply({
+				content: 'Please enter a valid text channel',
+				ephemeral: true,
+			});
+			return;
+		}
+
+		//set the channel in the enmap
+		bdayChannels.set(interaction.guild!.id, guildChannel.id);
+
+		//get the hour and ensure that it is valid
+		let hour = interaction.options.getInteger('hour')!;
+		if (hour > 23 || hour < 0) {
+			return interaction.reply({
+				content:
+					'Invalid hour, please use military format (0-23) where 0 represents midnight.',
+				ephemeral: true,
+			});
+		}
+		//get the minute and ensure that it is valid
+		let minute = interaction.options.getInteger('minute')!;
+		if (minute > 60 || minute < 0) {
+			return interaction.reply({
+				content: 'Invalid minute, please provide an integer between 0 and 60',
+				ephemeral: true,
+			});
+		}
+
+		//get the timezone and modify the time to create parity with CST
+		let timezone = interaction.options.getString('timezone')!;
+		let tzChange = timezoneCode[timezone];
+		let cst = hour + tzChange;
+
+		//if the timezone requires the bot to scan for a different day, store a modifier that will be used in the scheduler
+		let date = 'x';
+		if (cst + tzChange >= 24) {
+			date = 'plus';
+			cst -= 24;
+		}
+		if (cst + tzChange < 0) {
+			date = 'minus';
+			cst += 24;
+		}
+
+		//set the infostring to be set into the scheduler, Format: MM-HH-DATEMOD-TIMEZONE
+		let infostring = `${minute}-${hour}-${date}-${timezone}`;
+		bdayTimes.set(interaction.guild!.id, infostring); //scheduler enmap
+		birthdayTimer(interaction.guild!.id, bot); //scheduler
+
+		//respond and exit
+		let hourText = hour.toString();
+		let minuteText = minute.toString();
+		if (hour < 10) hourText = '0' + hourText;
+		if (minute < 10) minuteText = '0' + minuteText;
+		let embed = new MessageEmbed()
+			.setColor('#ffffff')
+			.setDescription(
+				`Successfully scheduled your birthday timer for **\`${hourText}:${minuteText}\` \`${timezone.toUpperCase()}\`** in ${interaction.options.getChannel(
+					'channel'
+				)}`
+			);
+		interaction.reply({ embeds: [embed] });
+		return;
+	}
+	guildRequired?: boolean | undefined = true;
+}


### PR DESCRIPTION
To avoid clutter in the slash command UI for admins and non admins alike I split birthday set and birthday config into two files:
Birthday and BirthdayConfig.

I also fix the visual presentation of BirthdayConfigs interaction.reply() and add timezone support for EU