### PR TITLE
Mirror Managers

### DIFF
--- a/src/events/InteractionCreate.ts
+++ b/src/events/InteractionCreate.ts
@@ -1,5 +1,6 @@
 import { CommandInteraction, TextChannel } from 'discord.js';
 import { Bot } from '../Bot';
+import { managerCheck } from '../resources/managerCheck';
 import { EventHandler } from './EventHandler';
 
 export class InteractionCreate implements EventHandler {
@@ -24,7 +25,15 @@ export class InteractionCreate implements EventHandler {
 				return;
 			}
 		}
-
+		if (command.managerRequired) {
+			if (!(await managerCheck(interaction))) {
+				return interaction.reply({
+					content:
+						'This command can only be used by designated managers or admininstrators',
+					ephemeral: true,
+				});
+			}
+		}
 		//if the command requires permissions
 		if (command.requiredPermissions) {
 			if (

--- a/src/resources/managerCheck.ts
+++ b/src/resources/managerCheck.ts
@@ -6,7 +6,6 @@ export async function managerCheck(guild: Guild, user: User): Promise<boolean> {
 	if (member?.permissions.toArray().includes('ADMINISTRATOR')) return true;
 	let roleArray = managerRoles.ensure(guild.id, []);
 	for (let role of roleArray) {
-		console.log(role);
 		if (member?.roles.cache.has(role)) {
 			return true;
 		}

--- a/src/resources/managerCheck.ts
+++ b/src/resources/managerCheck.ts
@@ -1,0 +1,17 @@
+import { Guild, User, Permissions } from 'discord.js';
+import { managerRoles } from '../slashcommands/ManagerRole';
+
+export async function managerCheck(guild: Guild, user: User): Promise<boolean> {
+	let member = guild.members.cache.get(user.id);
+	if (member?.permissions.toArray().includes('ADMINISTRATOR')) return true;
+	let roleArray = managerRoles.ensure(guild.id, []);
+	for (let role of roleArray) {
+		console.log(role);
+		if (member?.roles.cache.has(role)) {
+			console.log('has role');
+			return true;
+		}
+	}
+	console.log('nada');
+	return false;
+}

--- a/src/resources/managerCheck.ts
+++ b/src/resources/managerCheck.ts
@@ -1,10 +1,10 @@
-import { Guild, User, Permissions } from 'discord.js';
+import { Guild, User, Permissions, Interaction } from 'discord.js';
 import { managerRoles } from '../slashcommands/ManagerRole';
 
-export async function managerCheck(guild: Guild, user: User): Promise<boolean> {
-	let member = guild.members.cache.get(user.id);
+export async function managerCheck(interaction: Interaction): Promise<boolean> {
+	let member = interaction.guild!.members.cache.get(interaction.user.id);
 	if (member?.permissions.toArray().includes('ADMINISTRATOR')) return true;
-	let roleArray = managerRoles.ensure(guild.id, []);
+	let roleArray = managerRoles.ensure(interaction.guild!.id, []);
 	for (let role of roleArray) {
 		if (member?.roles.cache.has(role)) {
 			return true;

--- a/src/resources/managerCheck.ts
+++ b/src/resources/managerCheck.ts
@@ -8,10 +8,8 @@ export async function managerCheck(guild: Guild, user: User): Promise<boolean> {
 	for (let role of roleArray) {
 		console.log(role);
 		if (member?.roles.cache.has(role)) {
-			console.log('has role');
 			return true;
 		}
 	}
-	console.log('nada');
 	return false;
 }

--- a/src/slashcommands/BirthdayConfig.ts
+++ b/src/slashcommands/BirthdayConfig.ts
@@ -77,15 +77,6 @@ export class BirthdayConfig implements SlashCommand {
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
-		//check if the user is a Manager or Admin
-		if (!(await managerCheck(interaction.guild!, interaction.user))) {
-			return interaction.reply({
-				content:
-					'This command can only be used by designated managers or admininstrators',
-				ephemeral: true,
-			});
-		}
-
 		//recieve the provided channel and check if its a text channel
 		var guildChannel = interaction.options.getChannel(
 			'channel'
@@ -156,4 +147,5 @@ export class BirthdayConfig implements SlashCommand {
 		return;
 	}
 	guildRequired?: boolean | undefined = true;
+	managerRequired?: boolean | undefined = true;
 }

--- a/src/slashcommands/BirthdayConfig.ts
+++ b/src/slashcommands/BirthdayConfig.ts
@@ -42,7 +42,7 @@ export class BirthdayConfig implements SlashCommand {
 	registerData: ApplicationCommandDataResolvable = {
 		name: this.name,
 		description:
-			'[ADMIN ONLY] Configure the time and channel to send the birthday messages',
+			'[MANAGER] Configure the time and channel to send the birthday messages',
 		options: [
 			{
 				name: 'channel',

--- a/src/slashcommands/BirthdayConfig.ts
+++ b/src/slashcommands/BirthdayConfig.ts
@@ -12,6 +12,7 @@ import { Bot } from '../Bot';
 import { SlashCommand } from './SlashCommand';
 import { birthdayTimer } from '../resources/birthdayTimer';
 import Enmap from 'enmap';
+import { managerCheck } from '../resources/managerCheck';
 
 const timezones = [
 	{ name: 'GMT', value: 'gmt' },
@@ -76,6 +77,9 @@ export class BirthdayConfig implements SlashCommand {
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
+		if (await !managerCheck(interaction.guild!, interaction.user)) {
+			return interaction.reply({ content: 'we are in boys' });
+		}
 		let member = interaction.member as GuildMember;
 
 		//check if the user is an administrator

--- a/src/slashcommands/BirthdayConfig.ts
+++ b/src/slashcommands/BirthdayConfig.ts
@@ -77,23 +77,12 @@ export class BirthdayConfig implements SlashCommand {
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
-		if (await !managerCheck(interaction.guild!, interaction.user)) {
-			return interaction.reply({ content: 'we are in boys' });
-		}
-		let member = interaction.member as GuildMember;
-
-		//check if the user is an administrator
-		if (!(interaction.channel instanceof TextChannel)) {
-			interaction.reply('Command must be used in a server');
-			return;
-		}
-		if (!member.permissionsIn(interaction.channel).has('ADMINISTRATOR')) {
-			interaction.reply({
+		//check if the user is a Manager or Admin
+		if (!(await managerCheck(interaction.guild!, interaction.user))) {
+			return interaction.reply({
 				content:
-					'This command is only for people with Administrator permissions',
-				ephemeral: true,
+					'This command can only be used by designated managers or admininstrators',
 			});
-			return;
 		}
 
 		//recieve the provided channel and check if its a text channel

--- a/src/slashcommands/BirthdayConfig.ts
+++ b/src/slashcommands/BirthdayConfig.ts
@@ -82,6 +82,7 @@ export class BirthdayConfig implements SlashCommand {
 			return interaction.reply({
 				content:
 					'This command can only be used by designated managers or admininstrators',
+				ephemeral: true,
 			});
 		}
 

--- a/src/slashcommands/Config.ts
+++ b/src/slashcommands/Config.ts
@@ -11,6 +11,7 @@ import { bdayChannels } from './BirthdayConfig';
 import { defaultVc } from './DefaultVc';
 import { updateChannels } from './Update';
 import { nsfw } from './Nsfw';
+import { managerRoles } from './ManagerRole';
 
 export class Config implements SlashCommand {
 	name: string = 'config';
@@ -49,6 +50,17 @@ export class Config implements SlashCommand {
 		if (nsfwToggle == 'on') {
 			lines[4][2] = '✅';
 		}
+		let managerArray = managerRoles.ensure(interaction.guild!.id, []);
+		let managerString = '';
+		if (managerArray.length == 0) {
+			managerString = 'Add Mirror Managers with `/managerroles`';
+		} else {
+			for (let role of managerArray) {
+				let getRole = interaction.guild?.roles.cache.get(role);
+				managerString = managerString + `${getRole}` + ', ';
+			}
+			managerString = managerString.slice(0, -2);
+		}
 		embed.addFields(
 			{
 				name: lines[0][0],
@@ -64,6 +76,11 @@ export class Config implements SlashCommand {
 				name: lines[0][2],
 				value: `${lines[1][2]}\n${lines[2][2]}\n${lines[3][2]}\n${lines[4][2]}`,
 				inline: true,
+			},
+			{
+				name: 'Mirror Manager Roles',
+				value: managerString,
+				inline: false,
 			}
 		);
 		return interaction.reply({ embeds: [embed] });

--- a/src/slashcommands/DefaultVc.ts
+++ b/src/slashcommands/DefaultVc.ts
@@ -12,6 +12,7 @@ import {
 import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 import Enmap from 'enmap';
 import { Bot } from '../Bot';
+import { managerCheck } from '../resources/managerCheck';
 import { SlashCommand } from './SlashCommand';
 
 export let defaultVc = new Enmap('defaultVc');
@@ -21,7 +22,7 @@ export class DefaultVc implements SlashCommand {
 	registerData: ApplicationCommandDataResolvable = {
 		name: this.name,
 		description:
-			'[ADMIN ONLY] Set a default voice channel for Mirror to join upon restart, will not play a sound',
+			'[MANAGER] Set a default voice channel for Mirror to join upon restart, will not play a sound',
 		options: [
 			{
 				name: 'channel',
@@ -36,17 +37,13 @@ export class DefaultVc implements SlashCommand {
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
-		let member = interaction.member as GuildMember;
-		if (
-			!(interaction.channel instanceof TextChannel) ||
-			!member.permissionsIn(interaction.channel!).has('ADMINISTRATOR')
-		) {
-			interaction.reply({
+		//check if the user is a Manager or Admin
+		if (!(await managerCheck(interaction.guild!, interaction.user))) {
+			return interaction.reply({
 				content:
-					'This command is only for people with Administrator permissions',
+					'This command can only be used by designated managers or admininstrators',
 				ephemeral: true,
 			});
-			return;
 		}
 		let channel = interaction.options.getChannel('channel');
 		if (!(channel instanceof VoiceChannel)) {

--- a/src/slashcommands/DefaultVc.ts
+++ b/src/slashcommands/DefaultVc.ts
@@ -37,14 +37,6 @@ export class DefaultVc implements SlashCommand {
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
-		//check if the user is a Manager or Admin
-		if (!(await managerCheck(interaction.guild!, interaction.user))) {
-			return interaction.reply({
-				content:
-					'This command can only be used by designated managers or admininstrators',
-				ephemeral: true,
-			});
-		}
 		let channel = interaction.options.getChannel('channel');
 		if (!(channel instanceof VoiceChannel)) {
 			interaction.reply({
@@ -69,7 +61,8 @@ export class DefaultVc implements SlashCommand {
 		interaction.reply({ embeds: [embed] });
 		return;
 	}
-	//TODO: guildRequired? = true;
+	guildRequired?: boolean | undefined = true;
+	managerRequired?: boolean | undefined = true;
 }
 
 export async function launchVoice(bot: Bot): Promise<void> {

--- a/src/slashcommands/ManagerRole.ts
+++ b/src/slashcommands/ManagerRole.ts
@@ -33,7 +33,6 @@ export class ManagerRole implements SlashCommand {
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
-		//check if the user is a Manager or Admin
 		let role = interaction.options.getRole('role') as Role;
 		if (role.managed) {
 			return interaction.reply({

--- a/src/slashcommands/ManagerRole.ts
+++ b/src/slashcommands/ManagerRole.ts
@@ -56,6 +56,7 @@ export class ManagerRole implements SlashCommand {
 			managerRoles.set(interaction.guild!.id, roleArray);
 			return interaction.reply({
 				content: `Successfully removed ${role} as a Mirror Manager`,
+				ephemeral: true,
 			});
 		}
 
@@ -71,6 +72,7 @@ export class ManagerRole implements SlashCommand {
 		managerRoles.set(interaction.guild!.id, roleArray);
 		return interaction.reply({
 			content: `Successfully added ${role} as a Mirror Manager`,
+			ephemeral: true,
 		});
 	}
 	guildRequired?: boolean | undefined = true;

--- a/src/slashcommands/ManagerRole.ts
+++ b/src/slashcommands/ManagerRole.ts
@@ -18,7 +18,7 @@ export class ManagerRole implements SlashCommand {
 	name: string = 'managerrole';
 	registerData: ApplicationCommandDataResolvable = {
 		name: this.name,
-		description: '[MANAGER ONLY] Add or remove a role as a manager',
+		description: '[MANAGER] Add or remove a role as a manager',
 		options: [
 			{
 				name: 'role',

--- a/src/slashcommands/ManagerRole.ts
+++ b/src/slashcommands/ManagerRole.ts
@@ -58,6 +58,15 @@ export class ManagerRole implements SlashCommand {
 				content: `Successfully removed ${role} as a Mirror Manager`,
 			});
 		}
+
+		//I fully expect us to never need this but if someone is just needlessly adding we should stop it
+		if (roleArray.length > 15) {
+			return interaction.reply({
+				content:
+					'Mirror limits servers to 15 manager roles. Please remove manager roles before adding more. If this is not possible contact a developer for more options',
+				ephemeral: true,
+			});
+		}
 		roleArray.push(role.id);
 		managerRoles.set(interaction.guild!.id, roleArray);
 		return interaction.reply({

--- a/src/slashcommands/ManagerRole.ts
+++ b/src/slashcommands/ManagerRole.ts
@@ -34,13 +34,6 @@ export class ManagerRole implements SlashCommand {
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
 		//check if the user is a Manager or Admin
-		if (!(await managerCheck(interaction.guild!, interaction.user))) {
-			return interaction.reply({
-				content:
-					'This command can only be used by designated managers or admininstrators',
-				ephemeral: true,
-			});
-		}
 		let role = interaction.options.getRole('role') as Role;
 		if (role.managed) {
 			return interaction.reply({
@@ -76,4 +69,5 @@ export class ManagerRole implements SlashCommand {
 		});
 	}
 	guildRequired?: boolean | undefined = true;
+	managerRequired?: boolean | undefined = true;
 }

--- a/src/slashcommands/ManagerRole.ts
+++ b/src/slashcommands/ManagerRole.ts
@@ -1,0 +1,64 @@
+import {
+	ApplicationCommandDataResolvable,
+	CommandInteraction,
+	CacheType,
+	TextChannel,
+	GuildMember,
+	Role,
+} from 'discord.js';
+import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
+import Enmap from 'enmap';
+import { Bot } from '../Bot';
+import { SlashCommand } from './SlashCommand';
+
+export const managerRoles = new Enmap('managerRoles');
+
+export class ManagerRole implements SlashCommand {
+	name: string = 'managerrole';
+	registerData: ApplicationCommandDataResolvable = {
+		name: this.name,
+		description: '[ADMIN ONLY] Add or remove a role as a manager',
+		options: [
+			{
+				name: 'role',
+				description: 'The role you want to add or remove as a manager',
+				type: ApplicationCommandOptionTypes.ROLE,
+				required: true,
+			},
+		],
+	};
+	requiredPermissions: bigint[] = [];
+	run(bot: Bot, interaction: CommandInteraction<CacheType>): Promise<void> {
+		//check if the user is an administrator
+		if (!(interaction.channel instanceof TextChannel)) {
+			return interaction.reply({
+				content: 'Command must be used in a server',
+				ephemeral: true,
+			});
+		}
+		let member = interaction.member as GuildMember;
+		if (!member.permissionsIn(interaction.channel).has('ADMINISTRATOR')) {
+			return interaction.reply({
+				content:
+					'This command is only for people with Administrator permissions',
+				ephemeral: true,
+			});
+		}
+		let role = interaction.options.getRole('role') as Role;
+		let roleArray = managerRoles.ensure(interaction.guild!.id, []);
+		if (roleArray.includes(role.id)) {
+			let ptr = roleArray.indexOf(role.id);
+			roleArray.splice(ptr);
+			managerRoles.set(interaction.guild!.id, roleArray);
+			return interaction.reply({
+				content: `Successfully removed ${role} as a Mirror Manager`,
+			});
+		}
+		roleArray.push(role.id);
+		managerRoles.set(interaction.guild!.id, roleArray);
+		return interaction.reply({
+			content: `Successfully added ${role} as a Mirror Manager`,
+		});
+	}
+	guildRequired?: boolean | undefined = true;
+}

--- a/src/slashcommands/Nsfw.ts
+++ b/src/slashcommands/Nsfw.ts
@@ -32,7 +32,8 @@ export class Nsfw implements SlashCommand {
 	name: string = 'nsfw';
 	registerData: ChatInputApplicationCommandData = {
 		name: this.name,
-		description: 'Check your current NSFW setting, or toggle it ON or OFF',
+		description:
+			'[MANAGER] Check your current NSFW setting, or toggle it ON or OFF',
 		options: [
 			{
 				name: 'toggle',

--- a/src/slashcommands/Nsfw.ts
+++ b/src/slashcommands/Nsfw.ts
@@ -12,6 +12,7 @@ import {
 import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 import Enmap from 'enmap';
 import { Bot } from '../Bot';
+import { managerCheck } from '../resources/managerCheck';
 import { SlashCommand } from './SlashCommand';
 
 const choices = [
@@ -47,18 +48,13 @@ export class Nsfw implements SlashCommand {
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
-		let member = interaction.member as GuildMember;
-		if (!(interaction.channel instanceof TextChannel)) {
-			interaction.reply('Command must be used in a server');
-			return;
-		}
-		if (!member.permissionsIn(interaction.channel!).has('ADMINISTRATOR')) {
-			interaction.reply({
+		//check if the user is a Manager or Admin
+		if (!(await managerCheck(interaction.guild!, interaction.user))) {
+			return interaction.reply({
 				content:
-					'This command is only for people with Administrator permissions',
+					'This command can only be used by designated managers or admininstrators',
 				ephemeral: true,
 			});
-			return;
 		}
 		var setting = nsfw.ensure(interaction.guild!.id, 'off');
 		const embed = new MessageEmbed();

--- a/src/slashcommands/Nsfw.ts
+++ b/src/slashcommands/Nsfw.ts
@@ -49,14 +49,6 @@ export class Nsfw implements SlashCommand {
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
-		//check if the user is a Manager or Admin
-		if (!(await managerCheck(interaction.guild!, interaction.user))) {
-			return interaction.reply({
-				content:
-					'This command can only be used by designated managers or admininstrators',
-				ephemeral: true,
-			});
-		}
 		var setting = nsfw.ensure(interaction.guild!.id, 'off');
 		const embed = new MessageEmbed();
 		if (interaction.options.getString('toggle') == 'on') {
@@ -78,4 +70,5 @@ export class Nsfw implements SlashCommand {
 		return;
 	}
 	guildRequired?: boolean | undefined = true;
+	managerRequired?: boolean | undefined = true;
 }

--- a/src/slashcommands/RemoveIntro.ts
+++ b/src/slashcommands/RemoveIntro.ts
@@ -11,6 +11,7 @@ import { unlink } from 'fs';
 import { Bot } from '../Bot';
 import { SlashCommand } from './SlashCommand';
 import { promisify } from 'util';
+import { managerCheck } from '../resources/managerCheck';
 
 export class RemoveIntro implements SlashCommand {
 	public name = 'removeintro';
@@ -31,18 +32,12 @@ export class RemoveIntro implements SlashCommand {
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
-		let member = interaction.member as GuildMember;
-		if (!(interaction.channel instanceof TextChannel)) {
-			interaction.reply('Command must be used in a server');
-			return;
-		}
-		if (!member.permissionsIn(interaction.channel!).has('ADMINISTRATOR')) {
-			interaction.reply({
+		if (!(await managerCheck(interaction.guild!, interaction.user))) {
+			return interaction.reply({
 				content:
-					'This command is only for people with Administrator permissions',
+					'This command can only be used by designated managers or admininstrators',
 				ephemeral: true,
 			});
-			return;
 		}
 		let badUser = interaction.options.getUser('user');
 		const promiseMeAnUnlink = promisify(unlink);
@@ -62,7 +57,7 @@ export class RemoveIntro implements SlashCommand {
 				});
 				return;
 			} else {
-				bot.logger.error(interaction.channel.id, this.name, err);
+				bot.logger.error(interaction.channel!.id, this.name, err);
 				interaction.reply({
 					content: 'Error detected, contact an admin for further details.',
 					ephemeral: true,

--- a/src/slashcommands/RemoveIntro.ts
+++ b/src/slashcommands/RemoveIntro.ts
@@ -16,7 +16,7 @@ export class RemoveIntro implements SlashCommand {
 	public name = 'removeintro';
 	public registerData = {
 		name: this.name,
-		description: '[ADMIN ONLY] Delete someones intro theme!',
+		description: '[MANAGER] Delete someones intro theme!',
 		options: [
 			{
 				name: 'user',

--- a/src/slashcommands/RemoveIntro.ts
+++ b/src/slashcommands/RemoveIntro.ts
@@ -32,13 +32,6 @@ export class RemoveIntro implements SlashCommand {
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
-		if (!(await managerCheck(interaction.guild!, interaction.user))) {
-			return interaction.reply({
-				content:
-					'This command can only be used by designated managers or admininstrators',
-				ephemeral: true,
-			});
-		}
 		let badUser = interaction.options.getUser('user');
 		const promiseMeAnUnlink = promisify(unlink);
 		try {
@@ -67,4 +60,5 @@ export class RemoveIntro implements SlashCommand {
 		}
 	}
 	guildRequired?: boolean = true;
+	managerRequired?: boolean | undefined = true;
 }

--- a/src/slashcommands/SilenceMember.ts
+++ b/src/slashcommands/SilenceMember.ts
@@ -84,4 +84,5 @@ export class SilenceMember implements SlashCommand {
 		});
 	}
 	guildRequired?: boolean | undefined = true;
+	managerRequired?: boolean | undefined = true;
 }

--- a/src/slashcommands/SlashCommand.ts
+++ b/src/slashcommands/SlashCommand.ts
@@ -15,4 +15,6 @@ export interface SlashCommand {
 	run(bot: Bot, interaction: CommandInteraction): Promise<void>;
 	//if the command needs to be run inside a guild
 	guildRequired?: boolean;
+	//if the command needs to be run by a manager or admin
+	managerRequired?: boolean;
 }

--- a/src/slashcommands/Update.ts
+++ b/src/slashcommands/Update.ts
@@ -36,15 +36,6 @@ export class Update implements SlashCommand {
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
-		//check if the user is a Manager or Admin
-		if (!(await managerCheck(interaction.guild!, interaction.user))) {
-			return interaction.reply({
-				content:
-					'This command can only be used by designated managers or admininstrators',
-				ephemeral: true,
-			});
-		}
-
 		let channel = interaction.options.getChannel('channel');
 		if (
 			!interaction.guild?.me
@@ -75,4 +66,5 @@ export class Update implements SlashCommand {
 		return;
 	}
 	guildRequired?: boolean = true;
+	managerRequired?: boolean | undefined = true;
 }

--- a/src/slashcommands/Update.ts
+++ b/src/slashcommands/Update.ts
@@ -11,6 +11,7 @@ import {
 import { SlashCommand } from './SlashCommand';
 import config from '../../config.json';
 import Enmap from 'enmap';
+import { managerCheck } from '../resources/managerCheck';
 
 export let updateChannels = new Enmap({ name: 'updateChannels' });
 
@@ -19,7 +20,7 @@ export class Update implements SlashCommand {
 	public registerData = {
 		name: this.name,
 		description:
-			'[ADMIN ONLY] Set the channel you wish to recieve Mirror update messages in',
+			'[MANAGER] Set the channel you wish to recieve Mirror update messages in',
 		options: [
 			{
 				name: 'channel',
@@ -35,22 +36,15 @@ export class Update implements SlashCommand {
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
 	): Promise<void> {
-		if (!(interaction.channel instanceof TextChannel)) {
-			interaction.reply('Command must be used in a server');
-			return;
-		}
-		let member = interaction.member as GuildMember;
-		if (
-			!member.permissionsIn(interaction.channel!).has('ADMINISTRATOR') &&
-			member.id != config.owner
-		) {
-			interaction.reply({
+		//check if the user is a Manager or Admin
+		if (!(await managerCheck(interaction.guild!, interaction.user))) {
+			return interaction.reply({
 				content:
-					'This command is only for people with Administrator permissions',
+					'This command can only be used by designated managers or admininstrators',
 				ephemeral: true,
 			});
-			return;
 		}
+
 		let channel = interaction.options.getChannel('channel');
 		if (
 			!interaction.guild?.me


### PR DESCRIPTION
Adds a slash command /managerrole that allows administrators to designate certain roles to have full Mirror functionality within a server.

Adds an event managerCheck() which checks if the user is an administrator or a manager.

Adds managerCheck() to:
- /removeintro
- /nsfw
- /update
- /defaultvc
- /birthdayconfig
- /managerrole
