### PR TITLE
Silencerole

### DIFF
--- a/src/events/InteractionCreate.ts
+++ b/src/events/InteractionCreate.ts
@@ -1,6 +1,7 @@
 import { CommandInteraction, TextChannel } from 'discord.js';
 import { Bot } from '../Bot';
 import { managerCheck } from '../resources/managerCheck';
+import { silenceCheck } from '../slashcommands/SilenceRole';
 import { EventHandler } from './EventHandler';
 
 export class InteractionCreate implements EventHandler {
@@ -30,6 +31,15 @@ export class InteractionCreate implements EventHandler {
 				return interaction.reply({
 					content:
 						'This command can only be used by designated managers or admininstrators',
+					ephemeral: true,
+				});
+			}
+		}
+		if(command.blockSilenced) {
+			if(await silenceCheck(interaction)){				
+				return interaction.reply({
+					content:
+						'This command cannot be used by silenced members',
 					ephemeral: true,
 				});
 			}

--- a/src/slashcommands/Config.ts
+++ b/src/slashcommands/Config.ts
@@ -63,7 +63,7 @@ export class Config implements SlashCommand {
 				}
 				managerString = managerString.slice(0, -2);
 			}
-			let silenceString = 'If you want to prevent someone from interacting with Introthemes, Birthdays, and Music Commands,\nadd a silenced role with `/silencerole`, or individual members with `/silencemember`';
+			let silenceString = 'To prevent someone interacting with Introthemes, Birthday Command or Music\n`/silencerole` or `/silencemember`';
 			if(silence){
 				let getRole = interaction.guild?.roles.cache.get(silence);
 				silenceString = `${getRole}`;

--- a/src/slashcommands/Config.ts
+++ b/src/slashcommands/Config.ts
@@ -11,6 +11,7 @@ import { defaultVc } from './DefaultVc';
 import { updateChannels } from './Update';
 import { nsfw } from './Nsfw';
 import { managerRoles } from './ManagerRole';
+import { silencedRole } from './SilenceRole'
 
 export class Config implements SlashCommand {
 	name: string = 'config';
@@ -35,6 +36,7 @@ export class Config implements SlashCommand {
 			let defaultVoice = defaultVc.get(interaction.guild!.id);
 			let update = updateChannels.get(interaction.guild!.id);
 			let nsfwToggle = nsfw.get(interaction.guild!.id);
+			let silence = silencedRole.get(interaction.guild!.id);
 			if (update) {
 				update = bot.client.channels.cache.get(update);
 				lines[1][2] = update;
@@ -61,6 +63,11 @@ export class Config implements SlashCommand {
 				}
 				managerString = managerString.slice(0, -2);
 			}
+			let silenceString = 'If you want to prevent someone from interacting with Introthemes, Birthdays, and Music Commands,\nadd a silenced role with `/silencerole`, or individual members with `/silencemember`';
+			if(silence){
+				let getRole = interaction.guild?.roles.cache.get(silence);
+				silenceString = `${getRole}`;
+			}
 			embed.addFields(
 				{
 					name: lines[0][0],
@@ -81,7 +88,13 @@ export class Config implements SlashCommand {
 					name: 'Mirror Manager Roles',
 					value: managerString,
 					inline: false,
+				},
+				{
+					name: 'Silenced Role',
+					value: silenceString,
+					inline: false
 				}
+				
 			);
 			return interaction.reply({ embeds: [embed] });
 		} catch (err) {

--- a/src/slashcommands/SilenceMember.ts
+++ b/src/slashcommands/SilenceMember.ts
@@ -30,17 +30,6 @@ export class SilenceMember implements SlashCommand {
 	};
 	requiredPermissions: bigint[] = [];
 	run(bot: Bot, interaction: CommandInteraction<CacheType>): Promise<void> {
-		let member = interaction.member as GuildMember;
-		if (!(interaction.channel instanceof TextChannel)) {
-			return interaction.reply('Command must be used in a server');
-		}
-		if (!member.permissionsIn(interaction.channel).has('ADMINISTRATOR')) {
-			return interaction.reply({
-				content:
-					'This command is only for people with Administrator permissions',
-				ephemeral: true,
-			});
-		}
 		let badUser = interaction.options.getUser('user');
 		if (badUser?.bot) {
 			return interaction.reply({
@@ -49,7 +38,6 @@ export class SilenceMember implements SlashCommand {
 			});
 		}
 		let userArray = silencedUsers.ensure(interaction.guild!.id, []);
-
 		//if the user is already silenced, we want to unsilence them
 		if (userArray.includes(badUser!.id)) {
 			let ptr = userArray.indexOf(badUser!.id);
@@ -62,7 +50,7 @@ export class SilenceMember implements SlashCommand {
 		}
 
 		let badMember = interaction.guild!.members.cache.get(badUser!.id); //need to pull member object for .permissionsIn()
-		if (badMember!.permissionsIn(interaction.channel).has('ADMINISTRATOR')) {
+		if (badMember!.permissionsIn(interaction.channel!.id).has('ADMINISTRATOR')) {
 			return interaction.reply({
 				content: 'Administrators cannot be silenced',
 				ephemeral: true,

--- a/src/slashcommands/SilenceMember.ts
+++ b/src/slashcommands/SilenceMember.ts
@@ -30,46 +30,54 @@ export class SilenceMember implements SlashCommand {
 	};
 	requiredPermissions: bigint[] = [];
 	run(bot: Bot, interaction: CommandInteraction<CacheType>): Promise<void> {
-		let badUser = interaction.options.getUser('user');
-		if (badUser?.bot) {
-			return interaction.reply({
-				content: 'Bots cannot be silenced',
-				ephemeral: true,
-			});
-		}
-		let userArray = silencedUsers.ensure(interaction.guild!.id, []);
-		//if the user is already silenced, we want to unsilence them
-		if (userArray.includes(badUser!.id)) {
-			let ptr = userArray.indexOf(badUser!.id);
-			userArray.splice(ptr);
+		try{
+			let badUser = interaction.options.getUser('user');
+			if (badUser?.bot) {
+				return interaction.reply({
+					content: 'Bots cannot be silenced',
+					ephemeral: true,
+				});
+			}
+			let userArray = silencedUsers.ensure(interaction.guild!.id, []);
+			//if the user is already silenced, we want to unsilence them
+			if (userArray.includes(badUser!.id)) {
+				let ptr = userArray.indexOf(badUser!.id);
+				userArray.splice(ptr);
+				silencedUsers.set(interaction.guild!.id, userArray);
+				return interaction.reply({
+					content: `Successfully unsilenced ${badUser}`,
+					ephemeral: true,
+				});
+			}
+
+			let badMember = interaction.guild!.members.cache.get(badUser!.id); //need to pull member object for .permissionsIn()
+			if (badMember!.permissionsIn(interaction.channel!.id).has('ADMINISTRATOR')) {
+				return interaction.reply({
+					content: 'Administrators cannot be silenced',
+					ephemeral: true,
+				});
+			}
+
+			if (userArray.length > 100) {
+				return interaction.reply({
+					content:
+						'Servers are limited to 100 members silenced. Please unsilence somemembers before silencing more.  If this is not possible please contact a developeer for more options',
+					ephemeral: true,
+				});
+			}
+			userArray.push(badUser?.id);
 			silencedUsers.set(interaction.guild!.id, userArray);
 			return interaction.reply({
-				content: `Successfully unsilenced ${badUser}`,
+				content: `Successfully silenced ${badUser}`,
 				ephemeral: true,
 			});
-		}
-
-		let badMember = interaction.guild!.members.cache.get(badUser!.id); //need to pull member object for .permissionsIn()
-		if (badMember!.permissionsIn(interaction.channel!.id).has('ADMINISTRATOR')) {
+		} catch (err) {
+			bot.logger.error(interaction.channel!.id, this.name, err);
 			return interaction.reply({
-				content: 'Administrators cannot be silenced',
+				content: 'Error: contact a developer to investigate',
 				ephemeral: true,
 			});
 		}
-
-		if (userArray.length > 100) {
-			return interaction.reply({
-				content:
-					'Servers are limited to 100 members silenced. Please unsilence somemembers before silencing more.  If this is not possible please contact a developeer for more options',
-				ephemeral: true,
-			});
-		}
-		userArray.push(badUser?.id);
-		silencedUsers.set(interaction.guild!.id, userArray);
-		return interaction.reply({
-			content: `Successfully silenced ${badUser}`,
-			ephemeral: true,
-		});
 	}
 	guildRequired?: boolean | undefined = true;
 	managerRequired?: boolean | undefined = true;

--- a/src/slashcommands/SilenceRole.ts
+++ b/src/slashcommands/SilenceRole.ts
@@ -25,6 +25,7 @@ export class SilenceRole implements SlashCommand {
         try{
             //TODO if someone attempts to set the same role that is already set, remove it
             let badRole = interaction.options.getRole('role') as Role;
+            
             if(badRole?.permissionsIn(interaction.channel!.id).has('ADMINISTRATOR')){
                 return interaction.reply({content: 'Roles with administrator permissions cannot be silenced!'});
             }
@@ -35,6 +36,10 @@ export class SilenceRole implements SlashCommand {
                 }
             }
             let currentRole =  silencedRole.get(interaction.guild!.id) as string;
+            if(badRole.id == currentRole) {
+                silencedRole.delete(interaction.guild!.id);
+                return interaction.reply({content: `Removed ${badRole} as silenced role`})
+            }
             silencedRole.set(interaction.guild!.id, badRole?.id);
             if(currentRole && currentRole != badRole.id){
                 let getRole = interaction.guild?.roles.cache.get(currentRole);
@@ -57,7 +62,6 @@ export class SilenceRole implements SlashCommand {
     }
     guildRequired?: boolean | undefined = true;
     managerRequired?: boolean | undefined = true;
-    
 }
 
 export async function silenceCheck(interaction: Interaction): Promise<boolean> {

--- a/src/slashcommands/SilenceRole.ts
+++ b/src/slashcommands/SilenceRole.ts
@@ -1,77 +1,99 @@
-import { ApplicationCommandDataResolvable, CommandInteraction, CacheType, Role, MessageEmbed, Interaction } from "discord.js";
-import { ApplicationCommandOptionTypes } from "discord.js/typings/enums";
-import Enmap from "enmap";
-import { Bot } from "../Bot";
-import { SlashCommand } from "./SlashCommand";
-import { managerRoles } from "./ManagerRole";
-import { silencedUsers } from "./SilenceMember";
+import {
+	ApplicationCommandDataResolvable,
+	CommandInteraction,
+	CacheType,
+	Role,
+	MessageEmbed,
+	Interaction,
+} from 'discord.js';
+import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
+import Enmap from 'enmap';
+import { Bot } from '../Bot';
+import { SlashCommand } from './SlashCommand';
+import { managerRoles } from './ManagerRole';
+import { silencedUsers } from './SilenceMember';
 
 export const silencedRole = new Enmap('SilencedRole');
 
 export class SilenceRole implements SlashCommand {
-    name: string = 'silencerole';
-    registerData: ApplicationCommandDataResolvable = {
-        name: this.name,
-        description: '[MANAGER] Set a role from using Birthday, Intro, or Music commands.',
-        options: [{
-            name: 'role',
-            description: 'The role to silence.',
-            type: ApplicationCommandOptionTypes.ROLE,
-            required: true,
-        }]
-    }
-    requiredPermissions: bigint[] = [];
-    run(bot: Bot, interaction: CommandInteraction<CacheType>): Promise<void> {
-        try{
-            //TODO if someone attempts to set the same role that is already set, remove it
-            let badRole = interaction.options.getRole('role') as Role;
-            
-            if(badRole?.permissionsIn(interaction.channel!.id).has('ADMINISTRATOR')){
-                return interaction.reply({content: 'Roles with administrator permissions cannot be silenced!'});
-            }
-            let managedRoles = managerRoles.ensure(interaction.guild!.id,[]);
-            for(let role of managedRoles){
-                if(role == badRole?.id){
-                    return interaction.reply({content: 'Manager Roles cannot be silenced!', ephemeral:true});
-                }
-            }
-            let currentRole =  silencedRole.get(interaction.guild!.id) as string;
-            if(badRole.id == currentRole) {
-                silencedRole.delete(interaction.guild!.id);
-                return interaction.reply({content: `Removed ${badRole} as silenced role`})
-            }
-            silencedRole.set(interaction.guild!.id, badRole?.id);
-            if(currentRole && currentRole != badRole.id){
-                let getRole = interaction.guild?.roles.cache.get(currentRole);
-                const embed = new MessageEmbed()
-                    .setColor('#FFFFFF')
-                    .setDescription(`Replaced role ${getRole} with ${badRole} as silenced role.  Members with this role will not be able to interact with Birthdays, Introthemes or Music Commands.`);
-                return interaction.reply({embeds:[embed]});
-            }
-            const embed = new MessageEmbed()
-                .setColor('#FFFFFF')
-                .setDescription(`Set ${badRole} as silenced, members with this role will not be able to react with Birthdays, Introthemes, and Music Commands`);
-                return interaction.reply({embeds:[embed]});
-        } catch (err) {
+	name: string = 'silencerole';
+	registerData: ApplicationCommandDataResolvable = {
+		name: this.name,
+		description:
+			'[MANAGER] Set a role from using Birthday, Intro, or Music commands.',
+		options: [
+			{
+				name: 'role',
+				description: 'The role to silence.',
+				type: ApplicationCommandOptionTypes.ROLE,
+				required: true,
+			},
+		],
+	};
+	requiredPermissions: bigint[] = [];
+	run(bot: Bot, interaction: CommandInteraction<CacheType>): Promise<void> {
+		try {
+			let badRole = interaction.options.getRole('role') as Role;
+
+			if (
+				badRole?.permissionsIn(interaction.channel!.id).has('ADMINISTRATOR')
+			) {
+				return interaction.reply({
+					content: 'Roles with administrator permissions cannot be silenced!',
+				});
+			}
+			let managedRoles = managerRoles.ensure(interaction.guild!.id, []);
+			for (let role of managedRoles) {
+				if (role == badRole?.id) {
+					return interaction.reply({
+						content: 'Manager Roles cannot be silenced!',
+						ephemeral: true,
+					});
+				}
+			}
+			let currentRole = silencedRole.get(interaction.guild!.id) as string;
+			if (badRole.id == currentRole) {
+				silencedRole.delete(interaction.guild!.id);
+				return interaction.reply({
+					content: `Removed ${badRole} as silenced role`,
+				});
+			}
+			silencedRole.set(interaction.guild!.id, badRole?.id);
+			if (currentRole && currentRole != badRole.id) {
+				let getRole = interaction.guild?.roles.cache.get(currentRole);
+				const embed = new MessageEmbed()
+					.setColor('#FFFFFF')
+					.setDescription(
+						`Replaced role ${getRole} with ${badRole} as silenced role.  Members with this role will not be able to interact with Birthdays, Introthemes or Music Commands.`
+					);
+				return interaction.reply({ embeds: [embed] });
+			}
+			const embed = new MessageEmbed()
+				.setColor('#FFFFFF')
+				.setDescription(
+					`Set ${badRole} as silenced, members with this role will not be able to react with Birthdays, Introthemes, and Music Commands`
+				);
+			return interaction.reply({ embeds: [embed] });
+		} catch (err) {
 			bot.logger.error(interaction.channel!.id, this.name, err);
 			return interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,
 			});
 		}
-    }
-    guildRequired?: boolean | undefined = true;
-    managerRequired?: boolean | undefined = true;
+	}
+	guildRequired?: boolean | undefined = true;
+	managerRequired?: boolean | undefined = true;
 }
 
 export async function silenceCheck(interaction: Interaction): Promise<boolean> {
-    let member = interaction.guild!.members.cache.get(interaction.user.id);
-    if (member?.permissions.toArray().includes('ADMINISTRATOR')) return false;
-    let silenced = silencedRole.get(interaction.guild!.id);
-    if(member?.roles.cache.has(silenced)) return true;
-    silenced = silencedUsers.get(interaction.guild!.id);
-    for(let user of silenced){
-        if(user == member!.id) return true;
-    }
-    return false;
+	let member = interaction.guild!.members.cache.get(interaction.user.id);
+	if (member?.permissions.toArray().includes('ADMINISTRATOR')) return false;
+	let silenced = silencedRole.get(interaction.guild!.id);
+	if (member?.roles.cache.has(silenced)) return true;
+	silenced = silencedUsers.get(interaction.guild!.id);
+	for (let user of silenced) {
+		if (user == member!.id) return true;
+	}
+	return false;
 }

--- a/src/slashcommands/SilenceRole.ts
+++ b/src/slashcommands/SilenceRole.ts
@@ -1,8 +1,9 @@
-import { ApplicationCommandDataResolvable, CommandInteraction, CacheType } from "discord.js";
+import { ApplicationCommandDataResolvable, CommandInteraction, CacheType, Role, MessageEmbed } from "discord.js";
 import { ApplicationCommandOptionTypes } from "discord.js/typings/enums";
 import Enmap from "enmap";
 import { Bot } from "../Bot";
 import { SlashCommand } from "./SlashCommand";
+import { managerRoles } from "./ManagerRole";
 
 const silencedRole = new Enmap('SilencedRole');
 
@@ -21,7 +22,24 @@ export class SilenceRole implements SlashCommand {
     requiredPermissions: bigint[] = [];
     run(bot: Bot, interaction: CommandInteraction<CacheType>): Promise<void> {
         try{
-            
+            let badRole = interaction.options.getRole('role') as Role;
+            if(badRole?.permissionsIn(interaction.channel!.id).has('ADMINISTRATOR')){
+                return interaction.reply({content: 'Roles with administrator permissions cannot be silenced!'});
+            }
+            let managedRoles = managerRoles.ensure(interaction.guild!.id,[]);
+            for(let role of managedRoles){
+                if(role == badRole?.id){
+                    return interaction.reply({content: 'Manager Roles cannot be silenced!', ephemeral:true});
+                }
+            }
+            let currentRole =  silencedRole.get(interaction.guild!.id);
+            currentRole = interaction.guild?.roles.cache.get(currentRole);
+            const embed = new MessageEmbed()
+                .setColor('#FFFFFF')
+                .setDescription(`Replaced role ${currentRole} with ${badRole} as silenced role.  Anyone with this role will not be able to interact with Birtdhays, Introthemes or Music Commands.`);
+            return interaction.reply({embeds:[embed]})
+
+
         } catch (err) {
 			bot.logger.error(interaction.channel!.id, this.name, err);
 			return interaction.reply({

--- a/src/slashcommands/SilenceRole.ts
+++ b/src/slashcommands/SilenceRole.ts
@@ -5,7 +5,7 @@ import { Bot } from "../Bot";
 import { SlashCommand } from "./SlashCommand";
 import { managerRoles } from "./ManagerRole";
 
-const silencedRole = new Enmap('SilencedRole');
+export const silencedRole = new Enmap('SilencedRole');
 
 export class SilenceRole implements SlashCommand {
     name: string = 'silencerole';
@@ -32,14 +32,19 @@ export class SilenceRole implements SlashCommand {
                     return interaction.reply({content: 'Manager Roles cannot be silenced!', ephemeral:true});
                 }
             }
-            let currentRole =  silencedRole.get(interaction.guild!.id);
-            currentRole = interaction.guild?.roles.cache.get(currentRole);
+            let currentRole =  silencedRole.get(interaction.guild!.id) as string;
+            silencedRole.set(interaction.guild!.id, badRole?.id);
+            if(currentRole && currentRole != badRole.id){
+                let getRole = interaction.guild?.roles.cache.get(currentRole);
+                const embed = new MessageEmbed()
+                    .setColor('#FFFFFF')
+                    .setDescription(`Replaced role ${getRole} with ${badRole} as silenced role.  Members with this role will not be able to interact with Birthdays, Introthemes or Music Commands.`);
+                return interaction.reply({embeds:[embed]});
+            }
             const embed = new MessageEmbed()
                 .setColor('#FFFFFF')
-                .setDescription(`Replaced role ${currentRole} with ${badRole} as silenced role.  Anyone with this role will not be able to interact with Birtdhays, Introthemes or Music Commands.`);
-            return interaction.reply({embeds:[embed]})
-
-
+                .setDescription(`Set ${badRole} as silenced, members with this role will not be able to react with Birthdays, Introthemes, and Music Commands`);
+                return interaction.reply({embeds:[embed]});
         } catch (err) {
 			bot.logger.error(interaction.channel!.id, this.name, err);
 			return interaction.reply({
@@ -47,8 +52,6 @@ export class SilenceRole implements SlashCommand {
 				ephemeral: true,
 			});
 		}
-
-        throw new Error("Method not implemented.");
     }
     guildRequired?: boolean | undefined = true;
     managerRequired?: boolean | undefined = true;

--- a/src/slashcommands/SilenceRole.ts
+++ b/src/slashcommands/SilenceRole.ts
@@ -86,7 +86,7 @@ export class SilenceRole implements SlashCommand {
 	managerRequired?: boolean | undefined = true;
 }
 
-export async function silenceCheck(interaction: Interaction): Promise<boolean> {
+export function silenceCheck(interaction: Interaction): boolean {
 	let member = interaction.guild!.members.cache.get(interaction.user.id);
 	if (member?.permissions.toArray().includes('ADMINISTRATOR')) return false;
 	let silenced = silencedRole.get(interaction.guild!.id);

--- a/src/slashcommands/SilenceRole.ts
+++ b/src/slashcommands/SilenceRole.ts
@@ -1,0 +1,38 @@
+import { ApplicationCommandDataResolvable, CommandInteraction, CacheType } from "discord.js";
+import { ApplicationCommandOptionTypes } from "discord.js/typings/enums";
+import Enmap from "enmap";
+import { Bot } from "../Bot";
+import { SlashCommand } from "./SlashCommand";
+
+const silencedRole = new Enmap('SilencedRole');
+
+export class SilenceRole implements SlashCommand {
+    name: string = 'silencerole';
+    registerData: ApplicationCommandDataResolvable = {
+        name: this.name,
+        description: '[MANAGER] Set a role from using Birthday, Intro, or Music commands.',
+        options: [{
+            name: 'role',
+            description: 'The role to silence.',
+            type: ApplicationCommandOptionTypes.ROLE,
+            required: true,
+        }]
+    }
+    requiredPermissions: bigint[] = [];
+    run(bot: Bot, interaction: CommandInteraction<CacheType>): Promise<void> {
+        try{
+            
+        } catch (err) {
+			bot.logger.error(interaction.channel!.id, this.name, err);
+			return interaction.reply({
+				content: 'Error: contact a developer to investigate',
+				ephemeral: true,
+			});
+		}
+
+        throw new Error("Method not implemented.");
+    }
+    guildRequired?: boolean | undefined = true;
+    managerRequired?: boolean | undefined = true;
+    
+}

--- a/src/slashcommands/SlashCommand.ts
+++ b/src/slashcommands/SlashCommand.ts
@@ -17,4 +17,6 @@ export interface SlashCommand {
 	guildRequired?: boolean;
 	//if the command needs to be run by a manager or admin
 	managerRequired?: boolean;
+	//if the command blocks silenced users/roles set true
+	blockSilenced?: boolean;
 }


### PR DESCRIPTION
Allows server admins to designate a role as 'silenced'

Adds a silenceCheck for individual slash commands. If true it will check a user if they are silenced or if they have the silenced role.

Visual update to /config