### PR TITLE
Handle error event + commandError

### DIFF
--- a/src/CustomLogger.ts
+++ b/src/CustomLogger.ts
@@ -44,9 +44,9 @@ export class CustomLogger extends Logger {
 		});
 	}
 
-	error(
-		channelId: string | undefined,
-		commandName: string | undefined,
+	commandError(
+		channelId: string,
+		commandName: string,
 		...args: unknown[]
 	): ILogObject {
 		if (commandName) {

--- a/src/events/Error.ts
+++ b/src/events/Error.ts
@@ -1,0 +1,9 @@
+import { Bot } from '../Bot';
+import { EventHandler } from './EventHandler';
+
+export class Error implements EventHandler {
+	eventName: string = 'error';
+	async process(bot: Bot, error: any): Promise<void> {
+		bot.logger.error(error);
+	}
+}

--- a/src/events/Events.ts
+++ b/src/events/Events.ts
@@ -3,10 +3,12 @@ import { InteractionCreate } from './InteractionCreate';
 import { MessageCreate } from './MessageCreate';
 import { Ready } from './Ready';
 import { VoiceStateUpdate } from './VoiceStateUpdate';
+import { Error } from './Error';
 
 export let Events: Array<EventHandler> = [
 	new InteractionCreate(),
 	new Ready(),
 	new VoiceStateUpdate(),
 	new MessageCreate(),
+	new Error(),
 ];

--- a/src/keywords/Cringe.ts
+++ b/src/keywords/Cringe.ts
@@ -32,7 +32,7 @@ export class Cringe implements Keyword {
 			let num = Math.floor(Math.random() * cringeDict.length);
 			message.reply(cringeDict[num]);
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/keywords/Fortbush.ts
+++ b/src/keywords/Fortbush.ts
@@ -19,7 +19,7 @@ export class Fortbush implements Keyword {
 		try {
 			message.react(':FortBush:816549663812485151');
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/keywords/KeywordTest.ts
+++ b/src/keywords/KeywordTest.ts
@@ -15,7 +15,7 @@ export class KeywordTest implements Keyword {
 		try {
 			message.reply(`Hello keyword user: ${message.author.username}`);
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/keywords/Mirror.ts
+++ b/src/keywords/Mirror.ts
@@ -16,7 +16,7 @@ export class Mirror implements Keyword {
 		try {
 			message.react('👀');
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/keywords/MirrorEmoji.ts
+++ b/src/keywords/MirrorEmoji.ts
@@ -16,7 +16,7 @@ export class MirrorEmoji implements Keyword {
 		try {
 			message.react('🪞');
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/keywords/Pog.ts
+++ b/src/keywords/Pog.ts
@@ -19,7 +19,7 @@ export class Pog implements Keyword {
 		try {
 			message.react(':JamesChamp:791190997236842506');
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/keywords/PogChamp.ts
+++ b/src/keywords/PogChamp.ts
@@ -19,7 +19,7 @@ export class PogChamp implements Keyword {
 		try {
 			message.react(':JamesChamp:791190997236842506');
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/keywords/Poggers.ts
+++ b/src/keywords/Poggers.ts
@@ -19,7 +19,7 @@ export class Poggers implements Keyword {
 		try {
 			message.react(':JamesChamp:791190997236842506');
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/keywords/SevenTwentySeven.ts
+++ b/src/keywords/SevenTwentySeven.ts
@@ -26,7 +26,7 @@ export class SevenTwentySeven implements Keyword {
 				.setTitle('**__WHEN YOU FUCKING SEE IT__**');
 			message.channel.send({ embeds: [embed] });
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/keywords/Warn.ts
+++ b/src/keywords/Warn.ts
@@ -16,7 +16,7 @@ export class Warn implements Keyword {
 			);
 			return;
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/keywords/whydidntitalktoher.ts
+++ b/src/keywords/whydidntitalktoher.ts
@@ -20,7 +20,7 @@ export class whydidntitalktoher implements Keyword {
 				.then(() => message.react('🇦'))
 				.then(() => message.react('🇳'));
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/messagecommands/Cringe.ts
+++ b/src/messagecommands/Cringe.ts
@@ -17,7 +17,7 @@ export class Cringe implements MessageCommand {
 			message.reply('🕴️');
 			return;
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/messagecommands/Cum.ts
+++ b/src/messagecommands/Cum.ts
@@ -25,7 +25,7 @@ export class Cum implements MessageCommand {
 			}
 			message.channel.send('Absolutely nothing');
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/messagecommands/Scurvy.ts
+++ b/src/messagecommands/Scurvy.ts
@@ -23,7 +23,7 @@ export class Scurvy implements MessageCommand {
 			);
 			return;
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/messagecommands/SendUpdate.ts
+++ b/src/messagecommands/SendUpdate.ts
@@ -36,7 +36,7 @@ export class SendUpdate implements MessageCommand {
 				await channelToUpdate.send({ embeds: [embed] });
 			});
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/messagecommands/Superidol.ts
+++ b/src/messagecommands/Superidol.ts
@@ -38,7 +38,7 @@ export class Superidol implements MessageCommand {
 			const superidolmp3 = createAudioResource('./music/superidol.mp3');
 			player.play(superidolmp3);
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/messagecommands/fuckimissheralready.ts
+++ b/src/messagecommands/fuckimissheralready.ts
@@ -37,7 +37,7 @@ export class fuckimissheralready implements MessageCommand {
 				.setFooter({ text: 'I feel you bro' });
 			message.channel.send({ embeds: [embed] });
 		} catch (err) {
-			bot.logger.error(message.channel!.id, this.name, err);
+			bot.logger.commandError(message.channel!.id, this.name, err);
 			message.reply({
 				content: 'Error: contact a developer to investigate',
 			});

--- a/src/slashcommands/Birthday.ts
+++ b/src/slashcommands/Birthday.ts
@@ -26,7 +26,7 @@ const monthCode = {
 	december: 12,
 } as monthIndex;
 
-const dayCap = {	
+const dayCap = {
 	january: 31,
 	february: 29,
 	march: 31,
@@ -117,7 +117,7 @@ export class Birthday implements SlashCommand {
 		],
 	};
 	requiredPermissions: bigint[] = [];
-	
+
 	async run(
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
@@ -131,12 +131,16 @@ export class Birthday implements SlashCommand {
 				});
 			}
 
-            if (interaction.options.getInteger('day')! > dayCap[interaction.options.getString('month')!] || interaction.options.getInteger('day')! < 1){
-                return interaction.reply({
-                    content: 'Please enter a valid date',
-                    ephemeral: true
-                })
-            }
+			if (
+				interaction.options.getInteger('day')! >
+					dayCap[interaction.options.getString('month')!] ||
+				interaction.options.getInteger('day')! < 1
+			) {
+				return interaction.reply({
+					content: 'Please enter a valid date',
+					ephemeral: true,
+				});
+			}
 
 			//store the date of birth in numerical form  DD-MM
 			let formattedBirthday = `${interaction.options.getInteger('day')}-${
@@ -158,7 +162,7 @@ export class Birthday implements SlashCommand {
 			interaction.reply({ embeds: [embed] });
 			return;
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/BirthdayConfig.ts
+++ b/src/slashcommands/BirthdayConfig.ts
@@ -161,7 +161,7 @@ export class BirthdayConfig implements SlashCommand {
 			interaction.reply({ embeds: [embed] });
 			return;
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Boey.ts
+++ b/src/slashcommands/Boey.ts
@@ -31,7 +31,7 @@ export class Boey implements SlashCommand {
 			interaction.reply({ embeds: [embed] });
 			return;
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Config.ts
+++ b/src/slashcommands/Config.ts
@@ -11,7 +11,7 @@ import { defaultVc } from './DefaultVc';
 import { updateChannels } from './Update';
 import { nsfw } from './Nsfw';
 import { managerRoles } from './ManagerRole';
-import { silencedRole } from './SilenceRole'
+import { silencedRole } from './SilenceRole';
 
 export class Config implements SlashCommand {
 	name: string = 'config';
@@ -63,8 +63,9 @@ export class Config implements SlashCommand {
 				}
 				managerString = managerString.slice(0, -2);
 			}
-			let silenceString = 'To prevent someone interacting with Introthemes, Birthday Command or Music\n`/silencerole` or `/silencemember`';
-			if(silence){
+			let silenceString =
+				'To prevent someone interacting with Introthemes, Birthday Command or Music\n`/silencerole` or `/silencemember`';
+			if (silence) {
 				let getRole = interaction.guild?.roles.cache.get(silence);
 				silenceString = `${getRole}`;
 			}
@@ -92,13 +93,12 @@ export class Config implements SlashCommand {
 				{
 					name: 'Silenced Role',
 					value: silenceString,
-					inline: false
+					inline: false,
 				}
-				
 			);
 			return interaction.reply({ embeds: [embed] });
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			return interaction.reply({
 				content: 'Error detected, contact an admin to investigate.',
 				ephemeral: true,

--- a/src/slashcommands/DefaultVc.ts
+++ b/src/slashcommands/DefaultVc.ts
@@ -73,7 +73,7 @@ export class DefaultVc implements SlashCommand {
 			interaction.reply({ embeds: [embed] });
 			return;
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Gavin.ts
+++ b/src/slashcommands/Gavin.ts
@@ -139,7 +139,7 @@ export class Gavin implements SlashCommand {
 			//slash commands make it pretty easy to validate user input before the command is actually run, so theoretically this shouldn't ever run either.
 			interaction.reply('Something screwed up. This should never happen.');
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Github.ts
+++ b/src/slashcommands/Github.ts
@@ -28,7 +28,7 @@ export class Github implements SlashCommand {
 			interaction.reply({ embeds: [embed] });
 			return;
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Help.ts
+++ b/src/slashcommands/Help.ts
@@ -111,7 +111,7 @@ export class Help implements SlashCommand {
 				reaction.users.remove(user.id); //remove the emoji so the user doesn't have to remove it themselves
 			});
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Intro.ts
+++ b/src/slashcommands/Intro.ts
@@ -80,7 +80,7 @@ export class Intro implements SlashCommand {
 				);
 				return;
 			}
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.editReply({
 				content: 'Error detected, contact an admin to investigate.',
 			});

--- a/src/slashcommands/Invite.ts
+++ b/src/slashcommands/Invite.ts
@@ -38,7 +38,7 @@ export class Invite implements SlashCommand {
 			interaction.reply({ embeds: [embed] });
 			return;
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Join.ts
+++ b/src/slashcommands/Join.ts
@@ -45,7 +45,7 @@ export class Join implements SlashCommand {
 			interaction.reply({ content: 'success', ephemeral: true }); //hides the reply to anyone but the user
 			return;
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Kanye.ts
+++ b/src/slashcommands/Kanye.ts
@@ -37,7 +37,7 @@ export class Kanye implements SlashCommand {
 				});
 			interaction.reply({ embeds: [embed] });
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Kawaii.ts
+++ b/src/slashcommands/Kawaii.ts
@@ -32,7 +32,7 @@ export class Kawaii implements SlashCommand {
 			let embed = new MessageEmbed().setColor('#0071b6').setImage(jsonData.url);
 			interaction.reply({ embeds: [embed] });
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Leave.ts
+++ b/src/slashcommands/Leave.ts
@@ -36,7 +36,7 @@ export class Leave implements SlashCommand {
 			interaction.reply('Left the voice channel :wave:');
 			return;
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Mirror.ts
+++ b/src/slashcommands/Mirror.ts
@@ -26,7 +26,7 @@ export class Mirror implements SlashCommand {
 				'https://cdn.discordapp.com/attachments/668116812680003597/933108457463230464/IMG_3906.png'
 			);
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Nasa.ts
+++ b/src/slashcommands/Nasa.ts
@@ -44,7 +44,7 @@ export class Nasa implements SlashCommand {
 			if (jsonData.copyright) embed.setAuthor({ name: jsonData.copyright }); //checks to see if the copyright item exists, then it will include it in the author slot.
 			interaction.editReply({ embeds: [embed] }); //technically deferReply() creates the reply, so we need to edit that.
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/News.ts
+++ b/src/slashcommands/News.ts
@@ -66,7 +66,7 @@ export class News implements SlashCommand {
 			embed.setThumbnail(jsonData.articles[0].urlToImage);
 			interaction.reply({ embeds: [embed] });
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Nsfw.ts
+++ b/src/slashcommands/Nsfw.ts
@@ -82,7 +82,7 @@ export class Nsfw implements SlashCommand {
 			interaction.reply({ embeds: [embed] });
 			return;
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Poll.ts
+++ b/src/slashcommands/Poll.ts
@@ -236,7 +236,7 @@ export class Poll implements SlashCommand {
 				);
 			});
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/RemoveIntro.ts
+++ b/src/slashcommands/RemoveIntro.ts
@@ -52,7 +52,7 @@ export class RemoveIntro implements SlashCommand {
 				});
 				return;
 			} else {
-				bot.logger.error(interaction.channel!.id, this.name, err);
+				bot.logger.commandError(interaction.channel!.id, this.name, err);
 				interaction.reply({
 					content: 'Error detected, contact an admin for further details.',
 					ephemeral: true,

--- a/src/slashcommands/Sicko.ts
+++ b/src/slashcommands/Sicko.ts
@@ -46,7 +46,7 @@ export class Sicko implements SlashCommand {
 			interaction.reply('reply lol');
 			return;
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/SilenceMember.ts
+++ b/src/slashcommands/SilenceMember.ts
@@ -30,7 +30,7 @@ export class SilenceMember implements SlashCommand {
 	};
 	requiredPermissions: bigint[] = [];
 	run(bot: Bot, interaction: CommandInteraction<CacheType>): Promise<void> {
-		try{
+		try {
 			let badUser = interaction.options.getUser('user');
 			if (badUser?.bot) {
 				return interaction.reply({
@@ -51,7 +51,9 @@ export class SilenceMember implements SlashCommand {
 			}
 
 			let badMember = interaction.guild!.members.cache.get(badUser!.id); //need to pull member object for .permissionsIn()
-			if (badMember!.permissionsIn(interaction.channel!.id).has('ADMINISTRATOR')) {
+			if (
+				badMember!.permissionsIn(interaction.channel!.id).has('ADMINISTRATOR')
+			) {
 				return interaction.reply({
 					content: 'Administrators cannot be silenced',
 					ephemeral: true,
@@ -72,7 +74,7 @@ export class SilenceMember implements SlashCommand {
 				ephemeral: true,
 			});
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			return interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/SilenceRole.ts
+++ b/src/slashcommands/SilenceRole.ts
@@ -75,7 +75,7 @@ export class SilenceRole implements SlashCommand {
 				);
 			return interaction.reply({ embeds: [embed] });
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			return interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Stock.ts
+++ b/src/slashcommands/Stock.ts
@@ -137,7 +137,7 @@ export class Stock implements SlashCommand {
 					return;
 				}
 			}
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Support.ts
+++ b/src/slashcommands/Support.ts
@@ -25,7 +25,7 @@ export class Support implements SlashCommand {
 			interaction.reply('discord.gg/uvdg2R5PAU');
 			return;
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Test.ts
+++ b/src/slashcommands/Test.ts
@@ -19,7 +19,7 @@ export class Test implements SlashCommand {
 		try {
 			interaction.reply(`Hello ${interaction.user.username}`);
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Update.ts
+++ b/src/slashcommands/Update.ts
@@ -81,7 +81,7 @@ export class Update implements SlashCommand {
 			interaction.reply({ embeds: [embed] });
 			return;
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,

--- a/src/slashcommands/Weather.ts
+++ b/src/slashcommands/Weather.ts
@@ -174,7 +174,7 @@ export class Weather implements SlashCommand {
 			//sends embed to the channel
 			interaction.reply({ embeds: [embed] });
 		} catch (err) {
-			bot.logger.error(interaction.channel!.id, this.name, err);
+			bot.logger.commandError(interaction.channel!.id, this.name, err);
 			interaction.reply({
 				content: 'Error: contact a developer to investigate',
 				ephemeral: true,


### PR DESCRIPTION
Reverts the overload of logger.error, creates a new function for errors from commands that want to be sent to the error discord channel, logger.commandError. Functionally the same.
Also has a simple handle for an error event (eg 522 timeout)