### PR TITLE
Options refactor

### DIFF
--- a/src/resources/dynamicImports.ts
+++ b/src/resources/dynamicImports.ts
@@ -11,8 +11,8 @@ export async function importSlashCommands(bot: Bot) {
 	for (let file of files) {
 		// if it's not a javascript file, ignore it
 		if (!file.endsWith('.js')) continue;
-		// if it's the base class or the old class holder file, ignore it
-		if (file == 'SlashCommand.js' || file == 'SlashCommands.js') continue;
+		// if it's the base classes, ignore it
+		if (file == 'SlashCommand.js' || file == 'Option.js') continue;
 		// get all the exports from the file
 		let module = await import(`${__dirname}/../slashcommands/${file}`);
 		// make a new object using the exported class

--- a/src/slashcommands/Birthday.ts
+++ b/src/slashcommands/Birthday.ts
@@ -7,6 +7,7 @@ import {
 import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 import Enmap from 'enmap';
 import { Bot } from '../Bot';
+import { Option } from './Option';
 import { silencedUsers } from './SilenceMember';
 import { SlashCommand } from './SlashCommand';
 
@@ -26,7 +27,7 @@ const monthCode = {
 	december: 12,
 } as monthIndex;
 
-const dayCap = {	
+const dayCap = {
 	january: 31,
 	february: 29,
 	march: 31,
@@ -96,28 +97,25 @@ export let bdayDates = new Enmap({ name: 'bdayDates' });
 
 export class Birthday implements SlashCommand {
 	name: string = 'birthday';
-	registerData: ApplicationCommandDataResolvable = {
-		name: this.name,
-		description:
-			'Set your birthday to recieve a Birthday message on your birthday!',
-		options: [
-			{
-				name: 'month',
-				description: 'Your birth month',
-				type: ApplicationCommandOptionTypes.STRING,
-				required: true,
-				choices: months,
-			},
-			{
-				name: 'day',
-				description: 'The date of your birthday',
-				type: ApplicationCommandOptionTypes.INTEGER,
-				required: true,
-			},
-		],
-	};
+	description =
+		'Set your birthday to recieve a Birthday message on your birthday!';
+	options = [
+		new Option(
+			'month',
+			'Your Birth Month',
+			ApplicationCommandOptionTypes.STRING,
+			true,
+			'may',
+			months
+		),
+		new Option(
+			'day',
+			'The date of your birthday',
+			ApplicationCommandOptionTypes.INTEGER,
+			true
+		),
+	];
 	requiredPermissions: bigint[] = [];
-	
 	async run(
 		bot: Bot,
 		interaction: CommandInteraction<CacheType>
@@ -131,12 +129,16 @@ export class Birthday implements SlashCommand {
 				});
 			}
 
-            if (interaction.options.getInteger('day')! > dayCap[interaction.options.getString('month')!] || interaction.options.getInteger('day')! < 1){
-                return interaction.reply({
-                    content: 'Please enter a valid date',
-                    ephemeral: true
-                })
-            }
+			if (
+				interaction.options.getInteger('day')! >
+					dayCap[interaction.options.getString('month')!] ||
+				interaction.options.getInteger('day')! < 1
+			) {
+				return interaction.reply({
+					content: 'Please enter a valid date',
+					ephemeral: true,
+				});
+			}
 
 			//store the date of birth in numerical form  DD-MM
 			let formattedBirthday = `${interaction.options.getInteger('day')}-${

--- a/src/slashcommands/BirthdayConfig.ts
+++ b/src/slashcommands/BirthdayConfig.ts
@@ -10,6 +10,7 @@ import {
 import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 import { Bot } from '../Bot';
 import { SlashCommand } from './SlashCommand';
+import { Option } from './Option';
 import { birthdayTimer } from '../resources/birthdayTimer';
 import Enmap from 'enmap';
 
@@ -38,39 +39,36 @@ export let bdayTimes = new Enmap({ name: 'bdayTimes' });
 
 export class BirthdayConfig implements SlashCommand {
 	name: string = 'birthdayconfig';
-	registerData: ApplicationCommandDataResolvable = {
-		name: this.name,
-		description:
-			'[MANAGER] Configure the time and channel to send the birthday messages',
-		options: [
-			{
-				name: 'channel',
-				description: 'Set the channel where the birthday messages are sent to',
-				required: true,
-				type: ApplicationCommandOptionTypes.CHANNEL,
-			},
-			{
-				name: 'hour',
-				description:
-					'The hour you want to send Birthday messages in local time, military format (0-23)',
-				type: 'INTEGER',
-				required: true,
-			},
-			{
-				name: 'minute',
-				description: 'The minute you want to send Birthday messages',
-				type: 'INTEGER',
-				required: true,
-			},
-			{
-				name: 'timezone',
-				description: 'Your local timezone',
-				type: 'STRING',
-				required: true,
-				choices: timezones,
-			},
-		],
-	};
+	description =
+		'[MANAGER] Configure the time and channel to send the birthday messages';
+	options = [
+		new Option(
+			'channel',
+			'Set the channel where the birthday messages are sent to',
+			ApplicationCommandOptionTypes.CHANNEL,
+			true
+		),
+		new Option(
+			'hour',
+			'The hour you want to send Birthday messages in local time, military format (0-23)',
+			ApplicationCommandOptionTypes.NUMBER,
+			true
+		),
+		new Option(
+			'minute',
+			'The minute you want to send Birthday messages',
+			ApplicationCommandOptionTypes.NUMBER,
+			true
+		),
+		new Option(
+			'timezone',
+			'Your local timezone',
+			ApplicationCommandOptionTypes.STRING,
+			true,
+			'cst',
+			timezones
+		),
+	];
 	requiredPermissions: bigint[] = [];
 	async run(
 		bot: Bot,

--- a/src/slashcommands/Boey.ts
+++ b/src/slashcommands/Boey.ts
@@ -9,10 +9,8 @@ import { SlashCommand } from './SlashCommand';
 
 export class Boey implements SlashCommand {
 	name: string = 'boey';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Sends Boeys stream information!',
-	};
+	description: string = 'Sends Boeys stream information!';
+	options = [];
 	requiredPermissions: bigint[] = [];
 	async run(
 		bot: Bot,

--- a/src/slashcommands/Config.ts
+++ b/src/slashcommands/Config.ts
@@ -11,14 +11,12 @@ import { defaultVc } from './DefaultVc';
 import { updateChannels } from './Update';
 import { nsfw } from './Nsfw';
 import { managerRoles } from './ManagerRole';
-import { silencedRole } from './SilenceRole'
+import { silencedRole } from './SilenceRole';
 
 export class Config implements SlashCommand {
 	name: string = 'config';
-	registerData: ApplicationCommandDataResolvable = {
-		name: this.name,
-		description: 'See the configuration settings for this server',
-	};
+	description = 'See the configuration settings for this server';
+	options = [];
 	requiredPermissions: bigint[] = [];
 	run(bot: Bot, interaction: CommandInteraction<CacheType>): Promise<void> {
 		try {
@@ -63,8 +61,9 @@ export class Config implements SlashCommand {
 				}
 				managerString = managerString.slice(0, -2);
 			}
-			let silenceString = 'To prevent someone interacting with Introthemes, Birthday Command or Music\n`/silencerole` or `/silencemember`';
-			if(silence){
+			let silenceString =
+				'To prevent someone interacting with Introthemes, Birthday Command or Music\n`/silencerole` or `/silencemember`';
+			if (silence) {
 				let getRole = interaction.guild?.roles.cache.get(silence);
 				silenceString = `${getRole}`;
 			}
@@ -92,9 +91,8 @@ export class Config implements SlashCommand {
 				{
 					name: 'Silenced Role',
 					value: silenceString,
-					inline: false
+					inline: false,
 				}
-				
 			);
 			return interaction.reply({ embeds: [embed] });
 		} catch (err) {

--- a/src/slashcommands/DefaultVc.ts
+++ b/src/slashcommands/DefaultVc.ts
@@ -12,25 +12,23 @@ import {
 import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 import Enmap from 'enmap';
 import { Bot } from '../Bot';
+import { Option, Subcommand } from './Option';
 import { SlashCommand } from './SlashCommand';
 
 export let defaultVc = new Enmap('defaultVc');
 
 export class DefaultVc implements SlashCommand {
 	name: string = 'defaultvc';
-	registerData: ApplicationCommandDataResolvable = {
-		name: this.name,
-		description:
-			'[MANAGER] Set a default voice channel for Mirror to join upon restart, will not play a sound',
-		options: [
-			{
-				name: 'channel',
-				type: ApplicationCommandOptionTypes.CHANNEL,
-				description: 'The channel you wish to designate as the default',
-				required: true,
-			},
-		],
-	};
+	description =
+		'[MANAGER] Set a default voice channel for Mirror to join upon restart, will not play a sound';
+	options: (Option | Subcommand)[] = [
+		new Option(
+			'channel',
+			'The channel you wish to designate as the default',
+			ApplicationCommandOptionTypes.CHANNEL,
+			true
+		),
+	];
 	requiredPermissions: bigint[] = [];
 	async run(
 		bot: Bot,

--- a/src/slashcommands/Gavin.ts
+++ b/src/slashcommands/Gavin.ts
@@ -7,9 +7,12 @@ import {
 	CommandInteraction,
 	Permissions,
 	MessageEmbed,
+	Options,
 } from 'discord.js';
+import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 import Enmap from 'enmap';
 import { Bot } from '../Bot';
+import { Option, Subcommand } from './Option';
 import { SlashCommand } from './SlashCommand';
 
 //If you add choices to a slash command's options, they will be the only thing a user can select/input.
@@ -32,54 +35,37 @@ let gav_records = new Enmap({ name: 'gav_records' }); //named enmaps are persist
 //dirt whore
 export class Gavin implements SlashCommand {
 	name: string = 'gavin';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Lift data',
-		options: [
-			{
-				name: 'all',
-				description: 'print all of the lift data',
-				type: 1,
-				required: false,
-			},
-			{
-				name: 'lift',
-				description: "show a specific lift's data",
-				type: 1,
-				required: false,
-				options: [
-					{
-						name: 'lifttype',
-						type: 'STRING',
-						description: 'the lift to display',
-						required: true,
-						choices: liftChoices,
-					},
-				],
-			},
-			{
-				name: 'setlift',
-				description: "set a specific lift's data",
-				type: 1,
-				required: false,
-				options: [
-					{
-						name: 'lifttype',
-						type: 'STRING',
-						description: 'the lift to set',
-						required: true,
-						choices: liftChoices,
-					},
-					{
-						name: 'lift',
-						type: 'NUMBER',
-						description: 'the lift record',
-						required: true,
-					},
-				],
-			},
-		],
-	};
+	description: string = 'Lift data';
+	options: (Option | Subcommand)[] = [
+		new Subcommand('all', 'print all of the lift data'),
+		new Subcommand('lift', "show a specific lift's data", [
+			new Option(
+				'lifttype',
+				'the lift to display',
+				ApplicationCommandOptionTypes.STRING,
+				true,
+				'deadlift',
+				liftChoices
+			),
+		]),
+		new Subcommand('setlift', "set a specific lift's data", [
+			new Option(
+				'lifttype',
+				'the lift to set',
+				ApplicationCommandOptionTypes.STRING,
+				true,
+				'deadlift',
+				liftChoices
+			),
+			new Option(
+				'lift',
+				'the lift record',
+				ApplicationCommandOptionTypes.NUMBER,
+				true,
+				1
+			),
+		]),
+	];
 	requiredPermissions: bigint[] = [
 		Permissions.FLAGS.SEND_MESSAGES,
 		Permissions.FLAGS.EMBED_LINKS,

--- a/src/slashcommands/Github.ts
+++ b/src/slashcommands/Github.ts
@@ -9,10 +9,8 @@ import { SlashCommand } from './SlashCommand';
 
 export class Github implements SlashCommand {
 	name: string = 'github';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'information about our github and user privacy',
-	};
+	description: string = 'information about our github and user privacy';
+	options = [];
 	requiredPermissions: bigint[] = [];
 	async run(
 		bot: Bot,

--- a/src/slashcommands/Help.ts
+++ b/src/slashcommands/Help.ts
@@ -14,10 +14,8 @@ import { SlashCommand } from './SlashCommand';
 
 export class Help implements SlashCommand {
 	name: string = 'help';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Information about the bot.',
-	};
+	description: string = 'Information about the bot';
+	options = [];
 	requiredPermissions: bigint[] = [
 		Permissions.FLAGS.SEND_MESSAGES,
 		Permissions.FLAGS.EMBED_LINKS,

--- a/src/slashcommands/Intro.ts
+++ b/src/slashcommands/Intro.ts
@@ -11,6 +11,8 @@ import mkdirp from 'mkdirp';
 import { SlashCommand } from './SlashCommand';
 import { Bot } from '../Bot';
 import { silencedUsers } from './SilenceMember';
+import { Option, Subcommand } from './Option';
+import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 
 interface Format {
 	approxDurationMs: number;
@@ -18,18 +20,15 @@ interface Format {
 
 export class Intro implements SlashCommand {
 	name: string = 'intro';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Update your intro theme!',
-		options: [
-			{
-				name: 'video',
-				type: 'STRING',
-				description: 'Youtube link to intro',
-				required: true,
-			},
-		],
-	};
+	description: string = 'Update your intro theme!';
+	options: (Option | Subcommand)[] = [
+		new Option(
+			'video',
+			'Youtube link to intro',
+			ApplicationCommandOptionTypes.STRING,
+			true
+		),
+	];
 	requiredPermissions: bigint[] = [];
 	async run(
 		bot: Bot,

--- a/src/slashcommands/Invite.ts
+++ b/src/slashcommands/Invite.ts
@@ -6,14 +6,13 @@ import {
 	Permissions,
 } from 'discord.js';
 import { Bot } from '../Bot';
+import { Option, Subcommand } from './Option';
 import { SlashCommand } from './SlashCommand';
 
 export class Invite implements SlashCommand {
 	name: string = 'invite';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Invite link for Mirror',
-	};
+	description: string = 'Invite link for Mirror';
+	options: (Option | Subcommand)[] = [];
 	requiredPermissions: bigint[] = [
 		Permissions.FLAGS.SEND_MESSAGES,
 		Permissions.FLAGS.EMBED_LINKS,

--- a/src/slashcommands/Join.ts
+++ b/src/slashcommands/Join.ts
@@ -13,14 +13,13 @@ import {
 	Permissions,
 } from 'discord.js';
 import { Bot } from '../Bot';
+import { Option, Subcommand } from './Option';
 import { SlashCommand } from './SlashCommand';
 
 export class Join implements SlashCommand {
 	name: string = 'join';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Have Mirror join your voice channel',
-	};
+	description: string = 'Have Mirror join your voice channel';
+	options: (Option | Subcommand)[] = [];
 	requiredPermissions: bigint[] = [Permissions.FLAGS.SEND_MESSAGES];
 	async run(
 		bot: Bot,

--- a/src/slashcommands/Kanye.ts
+++ b/src/slashcommands/Kanye.ts
@@ -13,10 +13,8 @@ import { SlashCommand } from './SlashCommand';
 
 export class Kanye implements SlashCommand {
 	name: string = 'kanye';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Kanye',
-	};
+	description: string = 'Kanye';
+	options = [];
 	requiredPermissions: bigint[] = [
 		Permissions.FLAGS.SEND_MESSAGES,
 		Permissions.FLAGS.EMBED_LINKS,

--- a/src/slashcommands/Kawaii.ts
+++ b/src/slashcommands/Kawaii.ts
@@ -9,14 +9,13 @@ import {
 } from 'discord.js';
 import fetch from 'node-fetch';
 import { Bot } from '../Bot';
+import { Option, Subcommand } from './Option';
 import { SlashCommand } from './SlashCommand';
 
 export class Kawaii implements SlashCommand {
 	name: string = 'kawaii';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Get a cute catgirl',
-	};
+	description: string = 'Get a cute catgirl';
+	options: (Option | Subcommand)[] = [];
 	requiredPermissions: bigint[] = [
 		Permissions.FLAGS.SEND_MESSAGES,
 		Permissions.FLAGS.EMBED_LINKS,

--- a/src/slashcommands/Leave.ts
+++ b/src/slashcommands/Leave.ts
@@ -7,14 +7,13 @@ import {
 	Permissions,
 } from 'discord.js';
 import { Bot } from '../Bot';
+import { Option, Subcommand } from './Option';
 import { SlashCommand } from './SlashCommand';
 
 export class Leave implements SlashCommand {
 	name: string = 'leave';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Have Mirror leave your voice channel.',
-	};
+	description: string = 'Have Mirror leave your voice channel.';
+	options: (Option | Subcommand)[] = [];
 	requiredPermissions: bigint[] = [
 		Permissions.FLAGS.SEND_MESSAGES,
 		Permissions.FLAGS.MOVE_MEMBERS,

--- a/src/slashcommands/ManagerRole.ts
+++ b/src/slashcommands/ManagerRole.ts
@@ -10,24 +10,22 @@ import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 import Enmap from 'enmap';
 import { Bot } from '../Bot';
 import { managerCheck } from '../resources/managerCheck';
+import { Option, Subcommand } from './Option';
 import { SlashCommand } from './SlashCommand';
 
 export const managerRoles = new Enmap('managerRoles');
 
 export class ManagerRole implements SlashCommand {
 	name: string = 'managerrole';
-	registerData: ApplicationCommandDataResolvable = {
-		name: this.name,
-		description: '[MANAGER] Add or remove a role as a manager',
-		options: [
-			{
-				name: 'role',
-				description: 'The role you want to add or remove as a manager',
-				type: ApplicationCommandOptionTypes.ROLE,
-				required: true,
-			},
-		],
-	};
+	description: string = '[MANAGER] Add or remove a role as a manager';
+	options: (Option | Subcommand)[] = [
+		new Option(
+			'role',
+			'The role you want to add or remove as a manager',
+			ApplicationCommandOptionTypes.ROLE,
+			true
+		),
+	];
 	requiredPermissions: bigint[] = [];
 	async run(
 		bot: Bot,

--- a/src/slashcommands/Mirror.ts
+++ b/src/slashcommands/Mirror.ts
@@ -8,14 +8,13 @@ import {
 	Permissions,
 } from 'discord.js';
 import { Bot } from '../Bot';
+import { Option, Subcommand } from './Option';
 import { SlashCommand } from './SlashCommand';
 
 export class Mirror implements SlashCommand {
 	name: string = 'mirror';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Mirror go brrrr',
-	};
+	description: string = 'Mirror go brrrr';
+	options: (Option | Subcommand)[] = [];
 	requiredPermissions: bigint[] = [Permissions.FLAGS.SEND_MESSAGES];
 	async run(
 		bot: Bot,

--- a/src/slashcommands/Nasa.ts
+++ b/src/slashcommands/Nasa.ts
@@ -11,13 +11,12 @@ import fetch from 'node-fetch';
 import { Bot } from '../Bot';
 import { SlashCommand } from './SlashCommand';
 import config from '../../config.json';
+import { Option, Subcommand } from './Option';
 
 export class Nasa implements SlashCommand {
 	name: string = 'nasa';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Get daily astronomy pictures',
-	};
+	description: string = 'Get daily astronomy pictures';
+	options: (Option | Subcommand)[] = [];
 	requiredPermissions: bigint[] = [
 		Permissions.FLAGS.SEND_MESSAGES,
 		Permissions.FLAGS.EMBED_LINKS,

--- a/src/slashcommands/News.ts
+++ b/src/slashcommands/News.ts
@@ -11,21 +11,20 @@ import { Bot } from '../Bot';
 import { SlashCommand } from './SlashCommand';
 import config from '../../config.json';
 import fetch from 'node-fetch';
+import { Option, Subcommand } from './Option';
+import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 
 export class News implements SlashCommand {
 	name: string = 'news';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Current news',
-		options: [
-			{
-				name: 'query',
-				type: 'STRING',
-				description: 'headlines to query, space separated',
-				required: true,
-			},
-		],
-	};
+	description: string = 'Current news';
+	options: (Option | Subcommand)[] = [
+		new Option(
+			'query',
+			'headling to query, space separated',
+			ApplicationCommandOptionTypes.STRING,
+			true
+		),
+	];
 	requiredPermissions: bigint[] = [];
 	async run(
 		bot: Bot,

--- a/src/slashcommands/Nsfw.ts
+++ b/src/slashcommands/Nsfw.ts
@@ -13,6 +13,7 @@ import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 import Enmap from 'enmap';
 import { Bot } from '../Bot';
 import { SlashCommand } from './SlashCommand';
+import { Option } from './Option';
 
 const choices = [
 	{
@@ -29,20 +30,18 @@ export let nsfw = new Enmap({ name: 'nsfw' });
 
 export class Nsfw implements SlashCommand {
 	name: string = 'nsfw';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description:
-			'[MANAGER] Check your current NSFW setting, or toggle it ON or OFF',
-		options: [
-			{
-				name: 'toggle',
-				description: 'Switch your servers NSFW status to ON or OFF',
-				type: ApplicationCommandOptionTypes.STRING,
-				required: false,
-				choices: choices,
-			},
-		],
-	};
+	description: string =
+		'[MANAGER] Check your current NSFW setting, or toggle it ON or OFF';
+	options = [
+		new Option(
+			'toggle',
+			'Switch your servers NSFW status to ON or OFF',
+			ApplicationCommandOptionTypes.STRING,
+			false,
+			'off',
+			choices
+		),
+	];
 	requiredPermissions: bigint[] = [Permissions.FLAGS.SEND_MESSAGES];
 	async run(
 		bot: Bot,

--- a/src/slashcommands/Option.ts
+++ b/src/slashcommands/Option.ts
@@ -1,0 +1,89 @@
+import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
+
+type Choices = {
+	name: string;
+	value: string | boolean | number;
+};
+
+type JsonOption = {
+	name: string;
+	description: string;
+	type: number;
+	required: boolean;
+	choices: Array<Choices> | undefined;
+};
+
+export class Option {
+	//Name of the option
+	_name: string;
+	//Description of the option
+	_description: string;
+	//type of the option, you can use the ApplicationCommandOptionTypes class to make code more readable.
+	_type: number;
+	//whether or not it's a required option
+	_required: boolean;
+	//Array of valid choices
+	_choices: Array<Choices> | undefined;
+	//Placeholder value, will be used eventually for automated testing.
+	public _placeholder: string | boolean | number | undefined;
+
+	constructor(
+		name: string,
+		description: string,
+		type: number,
+		required: boolean,
+		placeholder?: string | boolean | number,
+		choices?: Array<Choices>
+	) {
+		this._name = name;
+		this._description = description;
+		this._type = type;
+		this._required = required;
+		this._choices = choices;
+		this._placeholder = placeholder;
+	}
+
+	toJson(): JsonOption {
+		return {
+			name: this._name,
+			description: this._description,
+			type: this._type,
+			required: this._required,
+			choices: this._choices,
+		};
+	}
+}
+
+type JsonSubcommand = {
+	name: string;
+	description: string;
+	type: number;
+	options: Array<JsonOption>;
+};
+
+export class Subcommand {
+	_name: string;
+	_description: string;
+	_options: Array<Option> | undefined;
+	_type: number = ApplicationCommandOptionTypes.SUB_COMMAND;
+
+	constructor(name: string, description: string, options?: Array<Option>) {
+		this._name = name;
+		this._description = description;
+		if (options === undefined) options = [];
+		this._options = options;
+	}
+
+	toJson(): JsonSubcommand {
+		let jsonOptions = [];
+		for (let option of this._options!) {
+			jsonOptions.push(option.toJson());
+		}
+		return {
+			name: this._name,
+			description: this._description,
+			options: jsonOptions,
+			type: this._type,
+		};
+	}
+}

--- a/src/slashcommands/Poll.ts
+++ b/src/slashcommands/Poll.ts
@@ -2,16 +2,16 @@
 //Returns a custom in depth poll
 import {
 	MessageEmbed,
-	ReactionCollector,
 	Message,
 	Permissions,
 	CacheType,
-	ChatInputApplicationCommandData,
 	CommandInteraction,
 	User,
 	MessageReaction,
 } from 'discord.js';
+import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 import { Bot } from '../Bot';
+import { Option, Subcommand } from './Option';
 import { SlashCommand } from './SlashCommand';
 
 const progBar = [
@@ -44,84 +44,27 @@ const emoteIndex: index = {
 
 export class Poll implements SlashCommand {
 	name: string = 'poll';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Create a poll with up to 10 options',
-		options: [
-			{
-				name: 'title',
-				type: 'STRING',
-				description: 'Set the poll title',
-				required: true,
-			},
-			{
-				name: 'time',
-				type: 'INTEGER',
-				description: 'How many minutes you want the poll open',
-				required: true,
-			},
-			{
-				name: 'arguement1',
-				type: 'STRING',
-				description: 'first poll option',
-				required: true,
-			},
-			{
-				name: 'arguement2',
-				type: 'STRING',
-				description: 'second poll option',
-				required: true,
-			},
-			{
-				name: 'arguement3',
-				type: 'STRING',
-				description: 'third poll option',
-				required: false,
-			},
-			{
-				name: 'arguement4',
-				type: 'STRING',
-				description: 'fourth poll option',
-				required: false,
-			},
-			{
-				name: 'arguement5',
-				type: 'STRING',
-				description: 'fifth poll option',
-				required: false,
-			},
-			{
-				name: 'arguement6',
-				type: 'STRING',
-				description: 'sixth poll option',
-				required: false,
-			},
-			{
-				name: 'arguement7',
-				type: 'STRING',
-				description: 'seventh poll option',
-				required: false,
-			},
-			{
-				name: 'arguement8',
-				type: 'STRING',
-				description: 'eigth poll option',
-				required: false,
-			},
-			{
-				name: 'arguement9',
-				type: 'STRING',
-				description: 'ninth poll option',
-				required: false,
-			},
-			{
-				name: 'arguement10',
-				type: 'STRING',
-				description: 'tenth poll option',
-				required: false,
-			},
-		],
-	};
+	description: string = 'Create a poll with up to 10 options';
+	//I'm not writing the applicationcommandoptiontype property every time. STRING = 3
+	options: (Option | Subcommand)[] = [
+		new Option('title', 'Set the poll title', 3, true),
+		new Option(
+			'time',
+			'How many minutes you want the poll open',
+			ApplicationCommandOptionTypes.INTEGER,
+			true
+		),
+		new Option('argument1', 'first poll option', 3, true),
+		new Option('argument2', 'second poll option', 3, true),
+		new Option('argument3', 'third poll option', 3, false),
+		new Option('argument4', 'fourth poll option', 3, false),
+		new Option('argument5', 'fifth poll option', 3, false),
+		new Option('argument6', 'sixth poll option', 3, false),
+		new Option('argument7', 'seventh poll option', 3, false),
+		new Option('argument8', 'eigth poll option', 3, false),
+		new Option('argument9', 'ninth poll option', 3, false),
+		new Option('argument10', 'tenth poll option', 3, false),
+	];
 	requiredPermissions: bigint[] = [
 		Permissions.FLAGS.SEND_MESSAGES,
 		Permissions.FLAGS.MANAGE_MESSAGES,
@@ -134,7 +77,7 @@ export class Poll implements SlashCommand {
 	): Promise<void> {
 		try {
 			let options = interaction.options.data.slice(2); //Creates a new array of poll options separate from slash options title and time
-			//TODO: error test for empty arguements
+			//TODO: error test for empty arguments
 
 			const embed = new MessageEmbed()
 				.setColor('#FFFFFF')
@@ -175,7 +118,7 @@ export class Poll implements SlashCommand {
 				fetchReply: true,
 			})) as Message;
 
-			//react to the interaction for each arguement
+			//react to the interaction for each argument
 			for (let arg in options) {
 				await message.react(emoteKeys[arg]);
 			}

--- a/src/slashcommands/RemoveIntro.ts
+++ b/src/slashcommands/RemoveIntro.ts
@@ -11,21 +11,19 @@ import { unlink } from 'fs';
 import { Bot } from '../Bot';
 import { SlashCommand } from './SlashCommand';
 import { promisify } from 'util';
+import { Option, Subcommand } from './Option';
 
 export class RemoveIntro implements SlashCommand {
 	public name = 'removeintro';
-	public registerData = {
-		name: this.name,
-		description: '[MANAGER] Delete someones intro theme!',
-		options: [
-			{
-				name: 'user',
-				description: 'Member to remove intro',
-				type: 6,
-				required: true,
-			},
-		],
-	};
+	description: string = '[MANAGER] Delete someones intro theme!';
+	options: (Option | Subcommand)[] = [
+		new Option(
+			'user',
+			'Member to remove intro',
+			ApplicationCommandOptionTypes.USER,
+			true
+		),
+	];
 	public requiredPermissions = [];
 	async run(
 		bot: Bot,

--- a/src/slashcommands/Sicko.ts
+++ b/src/slashcommands/Sicko.ts
@@ -14,14 +14,13 @@ import {
 	Permissions,
 } from 'discord.js';
 import { Bot } from '../Bot';
+import { Option, Subcommand } from './Option';
 import { SlashCommand } from './SlashCommand';
 
 export class Sicko implements SlashCommand {
 	name: string = 'sicko';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Have Mirror join your voice channel/but sicko mode',
-	};
+	description: string = 'Have Mirror join your voice channel/but sicko mode';
+	options: (Option | Subcommand)[] = [];
 	requiredPermissions: bigint[] = [Permissions.FLAGS.SEND_MESSAGES];
 	async run(
 		bot: Bot,

--- a/src/slashcommands/SilenceMember.ts
+++ b/src/slashcommands/SilenceMember.ts
@@ -9,28 +9,26 @@ import {
 import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 import Enmap from 'enmap';
 import { Bot } from '../Bot';
+import { Option, Subcommand } from './Option';
 import { SlashCommand } from './SlashCommand';
 
 export const silencedUsers = new Enmap('silencedUsers');
 
 export class SilenceMember implements SlashCommand {
 	name: string = 'silencemember';
-	registerData: ApplicationCommandDataResolvable = {
-		name: this.name,
-		description:
-			'[ADMIN ONLY] Silence a member from using Intros or Setting their birthday.',
-		options: [
-			{
-				name: 'user',
-				description: 'The user to silence/unsilence',
-				required: true,
-				type: ApplicationCommandOptionTypes.USER,
-			},
-		],
-	};
+	description: string =
+		'[ADMIN ONLY] Silence a member from using Intros or Setting their birthday.';
+	options: (Option | Subcommand)[] = [
+		new Option(
+			'user',
+			'The user to silence/unsilence',
+			ApplicationCommandOptionTypes.USER,
+			true
+		),
+	];
 	requiredPermissions: bigint[] = [];
 	run(bot: Bot, interaction: CommandInteraction<CacheType>): Promise<void> {
-		try{
+		try {
 			let badUser = interaction.options.getUser('user');
 			if (badUser?.bot) {
 				return interaction.reply({
@@ -51,7 +49,9 @@ export class SilenceMember implements SlashCommand {
 			}
 
 			let badMember = interaction.guild!.members.cache.get(badUser!.id); //need to pull member object for .permissionsIn()
-			if (badMember!.permissionsIn(interaction.channel!.id).has('ADMINISTRATOR')) {
+			if (
+				badMember!.permissionsIn(interaction.channel!.id).has('ADMINISTRATOR')
+			) {
 				return interaction.reply({
 					content: 'Administrators cannot be silenced',
 					ephemeral: true,

--- a/src/slashcommands/SilenceRole.ts
+++ b/src/slashcommands/SilenceRole.ts
@@ -12,24 +12,22 @@ import { Bot } from '../Bot';
 import { SlashCommand } from './SlashCommand';
 import { managerRoles } from './ManagerRole';
 import { silencedUsers } from './SilenceMember';
+import { Option, Subcommand } from './Option';
 
 export const silencedRole = new Enmap('SilencedRole');
 
 export class SilenceRole implements SlashCommand {
 	name: string = 'silencerole';
-	registerData: ApplicationCommandDataResolvable = {
-		name: this.name,
-		description:
-			'[MANAGER] Set a role from using Birthday, Intro, or Music commands.',
-		options: [
-			{
-				name: 'role',
-				description: 'The role to silence.',
-				type: ApplicationCommandOptionTypes.ROLE,
-				required: true,
-			},
-		],
-	};
+	description: string =
+		'[MANAGER] Set a role from using Birthday, Intro, or Music commands.';
+	options: (Option | Subcommand)[] = [
+		new Option(
+			'role',
+			'The role to silence',
+			ApplicationCommandOptionTypes.ROLE,
+			true
+		),
+	];
 	requiredPermissions: bigint[] = [];
 	run(bot: Bot, interaction: CommandInteraction<CacheType>): Promise<void> {
 		try {

--- a/src/slashcommands/SlashCommand.ts
+++ b/src/slashcommands/SlashCommand.ts
@@ -4,11 +4,13 @@ import {
 	ApplicationCommandDataResolvable,
 	CommandInteraction,
 } from 'discord.js';
+import { Option, Subcommand } from './Option';
 
 export interface SlashCommand {
 	//name of the slash command as discord will register it. Must be all lowercase.
 	name: string;
-	registerData: ApplicationCommandDataResolvable;
+	description: string;
+	options: Array<Option | Subcommand>;
 	//an array of Permissions.FLAGS
 	requiredPermissions: Array<bigint>;
 	//function that will run on command execution

--- a/src/slashcommands/Stock.ts
+++ b/src/slashcommands/Stock.ts
@@ -12,21 +12,20 @@ import { Bot } from '../Bot';
 import { SlashCommand } from './SlashCommand';
 import config from '../../config.json';
 import fetch from 'node-fetch';
+import { Option, Subcommand } from './Option';
+import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 
 export class Stock implements SlashCommand {
 	name: string = 'stock';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Stock ticker data',
-		options: [
-			{
-				name: 'tickers',
-				type: 'STRING',
-				description: 'tickers to query, space separated',
-				required: true,
-			},
-		],
-	};
+	description: string = 'Stock ticker data';
+	options: (Option | Subcommand)[] = [
+		new Option(
+			'tickers',
+			'tickers to query, space separated',
+			ApplicationCommandOptionTypes.STRING,
+			true
+		),
+	];
 	requiredPermissions: bigint[] = [
 		Permissions.FLAGS.SEND_MESSAGES,
 		Permissions.FLAGS.EMBED_LINKS,

--- a/src/slashcommands/Support.ts
+++ b/src/slashcommands/Support.ts
@@ -5,14 +5,13 @@ import {
 	Permissions,
 } from 'discord.js';
 import { Bot } from '../Bot';
+import { Option, Subcommand } from './Option';
 import { SlashCommand } from './SlashCommand';
 
 export class Support implements SlashCommand {
 	name: string = 'support';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Join Mirrors public support server',
-	};
+	description: string = 'Join Mirrors public support server';
+	options: (Option | Subcommand)[] = [];
 	requiredPermissions: bigint[] = [
 		Permissions.FLAGS.SEND_MESSAGES,
 		Permissions.FLAGS.EMBED_LINKS,

--- a/src/slashcommands/Test.ts
+++ b/src/slashcommands/Test.ts
@@ -3,13 +3,12 @@
 import { Bot } from '../Bot';
 import { Permissions, CommandInteraction, CacheType } from 'discord.js';
 import { SlashCommand } from './SlashCommand';
+import { Option, Subcommand } from './Option';
 
 export class Test implements SlashCommand {
 	public name = 'test';
-	public registerData = {
-		name: this.name,
-		description: 'Replies with your name!',
-	};
+	description: string = 'Replies with your name!';
+	options: (Option | Subcommand)[] = [];
 	public requiredPermissions = [Permissions.FLAGS.SEND_MESSAGES];
 
 	public async run(

--- a/src/slashcommands/Update.ts
+++ b/src/slashcommands/Update.ts
@@ -7,28 +7,28 @@ import {
 	TextChannel,
 	Guild,
 	MessageEmbed,
+	Options,
 } from 'discord.js';
 import { SlashCommand } from './SlashCommand';
 import config from '../../config.json';
 import Enmap from 'enmap';
+import { Option, Subcommand } from './Option';
+import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 
 export let updateChannels = new Enmap({ name: 'updateChannels' });
 
 export class Update implements SlashCommand {
 	public name = 'update';
-	public registerData = {
-		name: this.name,
-		description:
-			'[MANAGER] Set the channel you wish to recieve Mirror update messages in',
-		options: [
-			{
-				name: 'channel',
-				description: 'The channel you wish to recieve update messages',
-				type: 7,
-				required: true,
-			},
-		],
-	};
+	description: string =
+		'[MANAGER] Set the channel you wish to recieve Mirror update messages in';
+	options: (Option | Subcommand)[] = [
+		new Option(
+			'channel',
+			'The channel you wish to recieve update messages',
+			ApplicationCommandOptionTypes.CHANNEL,
+			true
+		),
+	];
 	public requiredPermissions = [Permissions.FLAGS.SEND_MESSAGES];
 
 	public async run(

--- a/src/slashcommands/Weather.ts
+++ b/src/slashcommands/Weather.ts
@@ -13,6 +13,8 @@ import { SlashCommand } from './SlashCommand';
 import fetch from 'node-fetch';
 import { find } from 'geo-tz';
 import config from '../../config.json';
+import { Option, Subcommand } from './Option';
+import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 
 type emojiConverter = { [index: string]: string };
 const weatherEmoji = {
@@ -48,24 +50,21 @@ const cardinalDir = {
 
 export class Weather implements SlashCommand {
 	name: string = 'weather';
-	registerData: ChatInputApplicationCommandData = {
-		name: this.name,
-		description: 'Weather data',
-		options: [
-			{
-				name: 'city',
-				type: 'STRING',
-				description: 'City to query',
-				required: true,
-			},
-			{
-				name: 'state',
-				type: 'STRING',
-				description: 'Two letter state code',
-				required: false,
-			},
-		],
-	};
+	description: string = 'Weather data';
+	options: (Option | Subcommand)[] = [
+		new Option(
+			'city',
+			'City to query',
+			ApplicationCommandOptionTypes.STRING,
+			true
+		),
+		new Option(
+			'state',
+			'Two letter state code',
+			ApplicationCommandOptionTypes.STRING,
+			false
+		),
+	];
 	requiredPermissions: bigint[] = [
 		Permissions.FLAGS.SEND_MESSAGES,
 		Permissions.FLAGS.EMBED_LINKS,


### PR DESCRIPTION
Create two classes, Option and Subcommand.
This is the first step in getting a robust automatic testing feature up-and-running.
You no longer create a registerData property on commands, you set the name, description, and an array of options.
The registerSlashCommands function will take care of creating the jsonified data to send when registering the slash command.
Allows you to create a placeholder value for !some! option types, which will be used when testing.
Currently, this does nothing, but when unit_tests comes online it actually will.