### PR TITLE
Add pm2 to node packages to avoid manual restarts

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,9 @@
+module.exports ={
+    apps: [{
+        name: "Mirror",
+        script: "./built/src/index.js",
+        env: {
+            NODE_ENV: "production",
+        }
+    }]
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"mkdirp": "latest",
 		"node-cron": "latest",
 		"node-fetch": "^2.6.1",
+		"pm2": "^5.2.0",
 		"tslog": "^3.3.2",
 		"tweetnacl": "latest",
 		"typescript": "^4.5.5",

--- a/src/events/Ready.ts
+++ b/src/events/Ready.ts
@@ -5,6 +5,7 @@ import { birthdayTimer } from '../resources/birthdayTimer';
 import { registerSlashCommands } from '../resources/registerSlashCommands';
 import { launchVoice } from '../slashcommands/DefaultVc';
 import config from '../../config.json';
+import { TextChannel } from 'discord.js';
 
 export class Ready implements EventHandler {
 	eventName = 'ready';
@@ -18,5 +19,8 @@ export class Ready implements EventHandler {
 			birthdayTimer(guild.toString(), bot);
 		});
 		launchVoice(bot);
+		let now = new Date();
+		let channel = bot.client.channels.cache.get(config.error_channel) as TextChannel;
+		channel.send(`Mirror started at ${now.getHours()}:${now.getMinutes()} in ${config.mode} mode`);
 	}
 }


### PR DESCRIPTION
pm2 should prevent us from needing to manually restart the bot upon web disconnects.