### PR TITLE
YTDL: No longer accepting Spotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Find a YouTube video shorter than 10 seconds and paste the link into 'video' fie
 
 ### Music Player
 
-Mirror allows users to listen to songs and playlists from Spotify, YouTube, and Soundcloud.  Using [`/play`](src/slashcommands/Play.ts) or [`/playnext`](src/slashcommands/PlayNext.ts) you can search for songs or paste your own song or playlist and it will add it to the queue.
+Mirror allows users to listen to songs and playlists YouTube or Soundcloud.  Using [`/play`](src/slashcommands/Play.ts) or [`/playnext`](src/slashcommands/PlayNext.ts) you can search for songs or paste your own song or playlist and it will add it to the queue.
 
 The Music functionality includes many commands:
  - [`/shuffle`](src/slashcommands/Shuffle.ts)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"tweetnacl": "latest",
 		"typescript": "^4.5.5",
 		"ytdl": "latest",
-		"ytdl-core": "^4.10.0"
+		"ytdl-core": "^4.11.2"
 	},
 	"devDependencies": {
 		"@types/mkdirp": "^1.0.2",

--- a/src/resources/CustomPlayer.ts
+++ b/src/resources/CustomPlayer.ts
@@ -5,6 +5,7 @@ export class CustomPlayer extends Player{
     constructor(private bot: Bot){super(bot.client)};
     
     public playOptions: PlayerOptions = {
+        ytdlOptions:{ filter: "audioonly" }, //fix attempt for WRITE EPIPE error
         leaveOnEnd: false,
         leaveOnEmpty: false,
         leaveOnStop: false,

--- a/src/slashcommands/Play.ts
+++ b/src/slashcommands/Play.ts
@@ -44,7 +44,7 @@ export class Play implements SlashCommand {
 				})
 				.catch(() => {});
 			if (!searchResult || !searchResult.tracks.length)
-				return void interaction.editReply('no results were found');
+				return void interaction.editReply('No results were found, please send a unprivate Youtube or Soundcloud link');
 			
 			bot.logger.info(searchResult.tracks[0].title);
 

--- a/src/slashcommands/Play.ts
+++ b/src/slashcommands/Play.ts
@@ -45,6 +45,8 @@ export class Play implements SlashCommand {
 				.catch(() => {});
 			if (!searchResult || !searchResult.tracks.length)
 				return void interaction.editReply('no results were found');
+			
+			bot.logger.info(searchResult.tracks[0].title);
 
 			const queue = await bot.player.createQueue(guild!, bot.player.playOptions);
 


### PR DESCRIPTION
It is the copyright apocalypse and Spotify's terms of service no longer allow scraping songs off their API.  As such YTDL no longer can grab spotify links so I have adjust our documentation and updated our YTDL version to account for these changes.